### PR TITLE
oneAPI DPC++-based plugin: Predictor fixes, additional objective function

### DIFF
--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -16,6 +16,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   // Constant representing the device ID of CPU.
   static int32_t constexpr kCpuId = -1;
   static int64_t constexpr kDefaultSeed = 0;
+  static int32_t constexpr kDefaultId = -1;
 
  public:
   // stored random seed
@@ -32,6 +33,9 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   // gpu page size in external memory mode, 0 means using the default.
   size_t gpu_page_size;
   bool validate_parameters {false};
+
+  // primary oneAPI device, -1 means default device
+  int device_id;
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {
@@ -83,6 +87,10 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
 "\n\tDeprecated. Single process multi-GPU training is no longer supported."
 "\n\tPlease switch to distributed training with one process per GPU."
 "\n\tThis can be done using Dask or Spark.  See documentation for details.");
+    DMLC_DECLARE_FIELD(device_id)
+        .set_default(kDefaultId)
+        .set_lower_bound(-1)
+        .describe("The primary oneAPI device ordinal.");
   }
 
  private:

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -29,6 +29,7 @@ if (PLUGIN_UPDATER_ONEAPI)
   add_library(oneapi_plugin OBJECT
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/hist_util_oneapi.cc
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/regression_obj_oneapi.cc
+    ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/multiclass_obj_oneapi.cc
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/predictor_oneapi.cc)
   target_include_directories(oneapi_plugin
     PRIVATE

--- a/plugin/updater_oneapi/multiclass_obj_oneapi.cc
+++ b/plugin/updater_oneapi/multiclass_obj_oneapi.cc
@@ -1,0 +1,249 @@
+/*!
+ * Copyright 2015-2021 by Contributors
+ * \file multiclass_obj_oneapi.cc
+ * \brief Definition of multi-class classification objectives.
+ */
+#include <vector>
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "xgboost/parameter.h"
+#include "xgboost/data.h"
+#include "xgboost/logging.h"
+#include "xgboost/objective.h"
+#include "xgboost/json.h"
+
+#include "CL/sycl.hpp"
+
+namespace xgboost {
+namespace obj {
+
+DMLC_REGISTRY_FILE_TAG(multiclass_obj_oneapi);
+
+/*!
+ * \brief Do inplace softmax transformaton on start to end
+ *
+ * \tparam Iterator Input iterator type
+ *
+ * \param start Start iterator of input
+ * \param end end iterator of input
+ */
+template <typename Iterator>
+inline void SoftmaxOneAPI(Iterator start, Iterator end) {
+  bst_float wmax = *start;
+  for (Iterator i = start+1; i != end; ++i) {
+    wmax = cl::sycl::max(*i, wmax);
+  }
+  double wsum = 0.0f;
+  for (Iterator i = start; i != end; ++i) {
+    *i = cl::sycl::exp(*i - wmax);
+    wsum += *i;
+  }
+  for (Iterator i = start; i != end; ++i) {
+    *i /= static_cast<float>(wsum);
+  }
+}
+
+/*!
+ * \brief Find the maximum iterator within the iterators
+ * \param begin The begining iterator.
+ * \param end The end iterator.
+ * \return the iterator point to the maximum value.
+ * \tparam Iterator The type of the iterator.
+ */
+template<typename Iterator>
+inline Iterator FindMaxIndexOneAPI(Iterator begin, Iterator end) {
+  Iterator maxit = begin;
+  for (Iterator it = begin; it != end; ++it) {
+    if (*it > *maxit) maxit = it;
+  }
+  return maxit;
+}
+
+struct SoftmaxMultiClassParamOneAPI : public XGBoostParameter<SoftmaxMultiClassParamOneAPI> {
+  int num_class;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(SoftmaxMultiClassParamOneAPI) {
+    DMLC_DECLARE_FIELD(num_class).set_lower_bound(1)
+        .describe("Number of output class in the multi-class classification.");
+  }
+};
+
+class SoftmaxMultiClassObjOneAPI : public ObjFunction {
+ public:
+  explicit SoftmaxMultiClassObjOneAPI(bool output_prob)
+  : output_prob_(output_prob) {}
+
+  void Configure(Args const& args) override {
+    param_.UpdateAllowUnknown(args);
+
+    cl::sycl::default_selector selector;
+    qu_ = cl::sycl::queue(selector);
+  }
+
+  void GetGradient(const HostDeviceVector<bst_float>& preds,
+                   const MetaInfo& info,
+                   int iter,
+                   HostDeviceVector<GradientPair>* out_gpair) override {
+    if (info.labels_.Size() == 0) {
+      return;
+    }
+    CHECK(preds.Size() == (static_cast<size_t>(param_.num_class) * info.labels_.Size()))
+        << "SoftmaxMultiClassObjOneAPI: label size and pred size does not match.\n"
+        << "label.Size() * num_class: "
+        << info.labels_.Size() * static_cast<size_t>(param_.num_class) << "\n"
+        << "num_class: " << param_.num_class << "\n"
+        << "preds.Size(): " << preds.Size();
+
+    const int nclass = param_.num_class;
+    const auto ndata = static_cast<int64_t>(preds.Size() / nclass);
+
+    out_gpair->Resize(preds.Size());
+
+    const bool is_null_weight = info.weights_.Size() == 0;
+    if (!is_null_weight) {
+      CHECK_EQ(info.weights_.Size(), ndata)
+          << "Number of weights should be equal to number of data points.";
+    }
+
+    cl::sycl::buffer<bst_float, 1> preds_buf(preds.HostPointer(), preds.Size());
+    cl::sycl::buffer<bst_float, 1> labels_buf(info.labels_.HostPointer(), info.labels_.Size());
+    cl::sycl::buffer<GradientPair, 1> out_gpair_buf(out_gpair->HostPointer(), out_gpair->Size());
+    cl::sycl::buffer<bst_float, 1> weights_buf(is_null_weight ? NULL : info.weights_.HostPointer(),
+                                               is_null_weight ? 1 : info.weights_.Size());
+
+    cl::sycl::buffer<int, 1> additional_input_buf(1);
+	{
+		auto additional_input_acc = additional_input_buf.template get_access<cl::sycl::access::mode::write>();
+		additional_input_acc[0] = 1; // Fill the label_correct flag
+	}
+
+    qu_.submit([&](cl::sycl::handler& cgh) {
+      auto preds_acc            = preds_buf.template get_access<cl::sycl::access::mode::read>(cgh);
+      auto labels_acc           = labels_buf.template get_access<cl::sycl::access::mode::read>(cgh);
+      auto weights_acc          = weights_buf.template get_access<cl::sycl::access::mode::read>(cgh);
+      auto out_gpair_acc        = out_gpair_buf.template get_access<cl::sycl::access::mode::write>(cgh);
+      auto additional_input_acc = additional_input_buf.template get_access<cl::sycl::access::mode::write>(cgh);
+      cgh.parallel_for<>(cl::sycl::range<1>(ndata), [=](cl::sycl::id<1> pid) {
+        int idx = pid[0];
+
+        bst_float const * point = &preds_acc[idx * nclass];
+
+        // Part of Softmax function
+        bst_float wmax = std::numeric_limits<bst_float>::min();
+        for (int k = 0; k < nclass; k++) { wmax = cl::sycl::max(point[k], wmax); }
+        double wsum = 0.0f;
+        for (int k = 0; k < nclass; k++) { wsum += cl::sycl::exp(point[k] - wmax); }
+        auto label = labels_acc[idx];
+        if (label < 0 || label >= nclass) {
+          additional_input_acc[0] = 0;
+          label = 0;
+        }
+        bst_float wt = is_null_weight ? 1.0f : weights_acc[idx];
+        for (int k = 0; k < nclass; ++k) {
+          bst_float p = expf(point[k] - wmax) / static_cast<float>(wsum);
+          const float eps = 1e-16f;
+          const bst_float h = cl::sycl::max(2.0f * p * (1.0f - p) * wt, eps);
+          p = label == k ? p - 1.0f : p;
+          out_gpair_acc[idx * nclass + k] = GradientPair(p * wt, h);
+        }
+      });
+    }).wait();
+
+    int flag = 1;
+	{
+		auto additional_input_acc = additional_input_buf.template get_access<cl::sycl::access::mode::read>();
+		flag = additional_input_acc[0];
+	}
+
+    if (flag == 0) {
+      LOG(FATAL) << "SoftmaxMultiClassObjOneAPI: label must be in [0, num_class).";
+    }
+  }
+  void PredTransform(HostDeviceVector<bst_float>* io_preds) override {
+    this->Transform(io_preds, output_prob_);
+  }
+  void EvalTransform(HostDeviceVector<bst_float>* io_preds) override {
+    this->Transform(io_preds, true);
+  }
+  const char* DefaultEvalMetric() const override {
+    return "mlogloss";
+  }
+
+  inline void Transform(HostDeviceVector<bst_float> *io_preds, bool prob) {
+    const int nclass = param_.num_class;
+    const auto ndata = static_cast<int64_t>(io_preds->Size() / nclass);
+    max_preds_.Resize(ndata);
+
+    {
+      cl::sycl::buffer<bst_float, 1> io_preds_buf(io_preds->HostPointer(), io_preds->Size());
+
+      if (prob) {
+        qu_.submit([&](cl::sycl::handler& cgh) {
+          auto io_preds_acc = io_preds_buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+          cgh.parallel_for<>(cl::sycl::range<1>(ndata), [=](cl::sycl::id<1> pid) {
+            int idx = pid[0];
+            bst_float * point = &io_preds_acc[idx * nclass];
+            SoftmaxOneAPI(point, point + nclass);
+          });
+        }).wait();
+      } else {
+        cl::sycl::buffer<bst_float, 1> max_preds_buf(max_preds_.HostPointer(), max_preds_.Size());
+
+        qu_.submit([&](cl::sycl::handler& cgh) {
+          auto io_preds_acc = io_preds_buf.template get_access<cl::sycl::access::mode::read>(cgh);
+          auto max_preds_acc = max_preds_buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+          cgh.parallel_for<>(cl::sycl::range<1>(ndata), [=](cl::sycl::id<1> pid) {
+            int idx = pid[0];
+            bst_float const * point = &io_preds_acc[idx * nclass];
+            max_preds_acc[idx] = FindMaxIndexOneAPI(point, point + nclass) - point;
+          });
+        }).wait();
+      }
+    }
+
+    if (!prob) {
+      io_preds->Resize(max_preds_.Size());
+      io_preds->Copy(max_preds_);
+    }
+  }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    if (this->output_prob_) {
+      out["name"] = String("multi:softprob_oneapi");
+    } else {
+      out["name"] = String("multi:softmax_oneapi");
+    }
+    out["softmax_multiclass_param"] = ToJson(param_);
+  }
+
+  void LoadConfig(Json const& in) override {
+    FromJson(in["softmax_multiclass_param"], &param_);
+  }
+
+ private:
+  // output probability
+  bool output_prob_;
+  // parameter
+  SoftmaxMultiClassParamOneAPI param_;
+  // Cache for max_preds
+  HostDeviceVector<bst_float> max_preds_;
+
+  cl::sycl::queue qu_;
+};
+
+// register the objective functions
+DMLC_REGISTER_PARAMETER(SoftmaxMultiClassParamOneAPI);
+
+XGBOOST_REGISTER_OBJECTIVE(SoftmaxMultiClassOneAPI, "multi:softmax_oneapi")
+.describe("Softmax for multi-class classification, output class index.")
+.set_body([]() { return new SoftmaxMultiClassObjOneAPI(false); });
+
+XGBOOST_REGISTER_OBJECTIVE(SoftprobMultiClassOneAPI, "multi:softprob_oneapi")
+.describe("Softmax for multi-class classification, output probability distribution.")
+.set_body([]() { return new SoftmaxMultiClassObjOneAPI(true); });
+
+}  // namespace obj
+}  // namespace xgboost

--- a/plugin/updater_oneapi/predictor_oneapi.cc
+++ b/plugin/updater_oneapi/predictor_oneapi.cc
@@ -5,13 +5,10 @@
 #include <limits>
 #include <mutex>
 
-#include "xgboost/base.h"
-#include "xgboost/data.h"
-#include "xgboost/predictor.h"
+#include "data_oneapi.h"
+
 #include "xgboost/tree_model.h"
 #include "xgboost/tree_updater.h"
-#include "xgboost/logging.h"
-#include "xgboost/host_device_vector.h"
 
 #include "../../src/data/adapter.h"
 #include "../../src/common/math.h"
@@ -24,83 +21,91 @@ namespace predictor {
 
 DMLC_REGISTRY_FILE_TAG(predictor_oneapi);
 
-/*! \brief Element from a sparse vector */
-struct EntryOneAPI {
-  /*! \brief feature index */
-  bst_feature_t index;
-  /*! \brief feature value */
-  bst_float fvalue;
-  /*! \brief default constructor */
-  EntryOneAPI() = default;
-  /*!
-   * \brief constructor with index and value
-   * \param index The feature or row index.
-   * \param fvalue The feature value.
-   */
-  EntryOneAPI(bst_feature_t index, bst_float fvalue) : index(index), fvalue(fvalue) {}
-
-  EntryOneAPI(const Entry& entry) : index(entry.index), fvalue(entry.fvalue) {}
-
-  /*! \brief reversely compare feature values */
-  inline static bool CmpValue(const EntryOneAPI& a, const EntryOneAPI& b) {
-    return a.fvalue < b.fvalue;
+class PredictorOneAPI : public Predictor {
+ public:
+  explicit PredictorOneAPI(GenericParameter const* generic_param) :
+      Predictor::Predictor{generic_param} {
+    bool is_cpu = false;
+    std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices();
+    for (size_t i = 0; i < devices.size(); i++)
+    {
+      LOG(INFO) << "device_id = " << i << ", name = " << devices[i].get_info<cl::sycl::info::device::name>();
+    }
+    if (generic_param->device_id != GenericParameter::kDefaultId) {
+    	int n_devices = (int)devices.size();
+    	CHECK_LT(generic_param->device_id, n_devices);
+    	is_cpu = devices[generic_param->device_id].is_cpu() | devices[generic_param->device_id].is_host();
+    }
+    LOG(INFO) << "device_id = " << generic_param->device_id << ", is_cpu = " << int(is_cpu);
+    
+    if (is_cpu)
+    {
+      predictor_backend_.reset(Predictor::Create("cpu_predictor", generic_param));
+    }
+    else
+    {
+      predictor_backend_.reset(Predictor::Create("oneapi_predictor_gpu", generic_param));
+    }
   }
-  inline bool operator==(const EntryOneAPI& other) const {
-    return (this->index == other.index && this->fvalue == other.fvalue);
+
+  void Configure(const std::vector<std::pair<std::string, std::string>>& args) override {
+  	if (predictor_backend_) {
+  	  predictor_backend_->Configure(args);
+  	}
   }
+
+  void PredictBatch(DMatrix *dmat, PredictionCacheEntry *predts,
+                    const gbm::GBTreeModel &model, uint32_t tree_begin,
+                    uint32_t tree_end = 0) const override {
+    predictor_backend_->PredictBatch(dmat, predts, model, tree_begin, tree_end);
+  }
+
+  bool InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
+                      const gbm::GBTreeModel &model, float missing,
+                      PredictionCacheEntry *out_preds, uint32_t tree_begin,
+                      unsigned tree_end) const override {
+  	return predictor_backend_->InplacePredict(x, p_m, model, missing, out_preds, tree_begin, tree_end);
+  }
+
+  void PredictInstance(const SparsePage::Inst& inst,
+                       std::vector<bst_float>* out_preds,
+                       const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
+  	predictor_backend_->PredictInstance(inst, out_preds, model, ntree_limit);
+  }
+
+  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_preds,
+                   const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
+    predictor_backend_->PredictLeaf(p_fmat, out_preds, model, ntree_limit);
+  }
+
+  void PredictContribution(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
+                           const gbm::GBTreeModel& model, uint32_t ntree_limit,
+                           std::vector<bst_float>* tree_weights,
+                           bool approximate, int condition,
+                           unsigned condition_feature) const override {
+    predictor_backend_->PredictContribution(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate, condition, condition_feature);
+  }
+
+  void PredictInteractionContributions(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_contribs,
+                                       const gbm::GBTreeModel& model, unsigned ntree_limit,
+                                       std::vector<bst_float>* tree_weights,
+                                       bool approximate) const override {
+    predictor_backend_->PredictInteractionContributions(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate);
+  }
+
+ protected:
+  void InitOutPredictions(const MetaInfo& info,
+                          HostDeviceVector<bst_float>* out_preds,
+                          const gbm::GBTreeModel& model) const override {
+    predictor_backend_->InitOutPredictions(info, out_preds, model);
+  }
+ 
+ private:
+
+  std::unique_ptr<Predictor> predictor_backend_;
 };
 
-struct DeviceMatrixOneAPI {
-  DMatrix* p_mat;  // Pointer to the original matrix on the host
-  cl::sycl::queue qu_;
-  size_t* row_ptr;
-  size_t row_ptr_size;
-  EntryOneAPI* data;
-
-  DeviceMatrixOneAPI(DMatrix* dmat, cl::sycl::queue qu) : p_mat(dmat), qu_(qu) {
-    size_t num_row = 0;
-    size_t num_nonzero = 0;
-    for (auto &batch : dmat->GetBatches<SparsePage>()) {
-      const auto& data_vec = batch.data.HostVector();
-      const auto& offset_vec = batch.offset.HostVector();
-      num_nonzero += data_vec.size();
-      num_row += batch.Size();
-    }
-
-    row_ptr = cl::sycl::malloc_shared<size_t>(num_row + 1, qu_);
-    data = cl::sycl::malloc_shared<EntryOneAPI>(num_nonzero, qu_);
-
-    size_t data_offset = 0;
-    for (auto &batch : dmat->GetBatches<SparsePage>()) {
-      const auto& data_vec = batch.data.HostVector();
-      const auto& offset_vec = batch.offset.HostVector();
-      size_t batch_size = batch.Size();
-      if (batch_size > 0) {
-        std::copy(offset_vec.data(), offset_vec.data() + batch_size,
-                  row_ptr + batch.base_rowid);
-        if (batch.base_rowid > 0) {
-          for(size_t i = 0; i < batch_size; i++)
-            row_ptr[i + batch.base_rowid] += batch.base_rowid;
-        }
-        std::copy(data_vec.data(), data_vec.data() + offset_vec[batch_size],
-                  data + data_offset);
-        data_offset += offset_vec[batch_size];
-      }
-    }
-    row_ptr[num_row] = data_offset;
-    row_ptr_size = num_row + 1;
-  }
-
-  ~DeviceMatrixOneAPI() {
-    if (row_ptr) {
-      cl::sycl::free(row_ptr, qu_);
-    }
-    if (data) {
-      cl::sycl::free(data, qu_);
-    }
-  }
-};
-
+/* Wrapper for descriptor of a tree node */
 struct DeviceNodeOneAPI {
   DeviceNodeOneAPI()
       : fidx(-1), left_child_idx(-1), right_child_idx(-1) {}
@@ -115,7 +120,7 @@ struct DeviceNodeOneAPI {
   int right_child_idx;
   NodeValue val;
 
-  DeviceNodeOneAPI(const RegTree::Node& n) {  // NOLINT
+  DeviceNodeOneAPI(const RegTree::Node& n) {
     this->left_child_idx = n.LeftChild();
     this->right_child_idx = n.RightChild();
     this->fidx = n.SplitIndex();
@@ -149,66 +154,55 @@ struct DeviceNodeOneAPI {
   float GetWeight() const { return val.leaf_weight; }
 };
 
+/* OneAPI implementation of a device model, storing tree structure in USM buffers to provide access from device kernels */
 class DeviceModelOneAPI {
  public:
   cl::sycl::queue qu_;
-  DeviceNodeOneAPI* nodes;
-  size_t* tree_segments;
-  int* tree_group;
+  USMVector<DeviceNodeOneAPI> nodes_;
+  USMVector<size_t> tree_segments_;
+  USMVector<int> tree_group_;
   size_t tree_beg_;
   size_t tree_end_;
-  int num_group;
+  int num_group_;
 
-  DeviceModelOneAPI() : nodes(nullptr), tree_segments(nullptr), tree_group(nullptr) {}
+  DeviceModelOneAPI() {}
 
-  ~DeviceModelOneAPI() {
-    Reset();
-  }
+  ~DeviceModelOneAPI() {}
 
-  void Reset() {
-    if (nodes)
-      cl::sycl::free(nodes, qu_);
-    if (tree_segments)
-      cl::sycl::free(tree_segments, qu_);
-    if (tree_group)
-      cl::sycl::free(tree_group, qu_);
-  }
-
-  void Init(const gbm::GBTreeModel& model, size_t tree_begin, size_t tree_end, cl::sycl::queue qu) {
+  void Init(cl::sycl::queue qu, const gbm::GBTreeModel& model, size_t tree_begin, size_t tree_end) {
     qu_ = qu;
     CHECK_EQ(model.param.size_leaf_vector, 0);
-    Reset();
 
-    tree_segments = cl::sycl::malloc_shared<size_t>((tree_end - tree_begin) + 1, qu_);
+    tree_segments_.Resize(qu_, (tree_end - tree_begin) + 1);
     int sum = 0;
-    tree_segments[0] = sum;
+    tree_segments_[0] = sum;
     for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
       sum += model.trees[tree_idx]->GetNodes().size();
-      tree_segments[tree_idx - tree_begin + 1] = sum;
+      tree_segments_[tree_idx - tree_begin + 1] = sum;
     }
 
-    nodes = cl::sycl::malloc_shared<DeviceNodeOneAPI>(sum, qu_);
+    nodes_.Resize(qu_, sum);
     for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
       auto& src_nodes = model.trees[tree_idx]->GetNodes();
       for (size_t node_idx = 0; node_idx < src_nodes.size(); node_idx++)
-        nodes[node_idx + tree_segments[tree_idx - tree_begin]] = src_nodes[node_idx];
+        nodes_[node_idx + tree_segments_[tree_idx - tree_begin]] = src_nodes[node_idx];
     }
 
-    tree_group = cl::sycl::malloc_shared<int>(model.tree_info.size(), qu_);
+    tree_group_.Resize(qu_, model.tree_info.size());
     for (size_t tree_idx = 0; tree_idx < model.tree_info.size(); tree_idx++)
-      tree_group[tree_idx] = model.tree_info[tree_idx];
+      tree_group_[tree_idx] = model.tree_info[tree_idx];
 
     tree_beg_ = tree_begin;
     tree_end_ = tree_end;
-    num_group = model.learner_model_param->num_output_group; 
+    num_group_ = model.learner_model_param->num_output_group; 
   }
 };
 
-float GetFvalue(int ridx, int fidx, EntryOneAPI* data, size_t* row_ptr, bool& is_missing) {
+float GetFvalue(int ridx, int fidx, Entry* data, size_t* row_ptr, bool& is_missing) {
   // Binary search
   auto begin_ptr = data + row_ptr[ridx];
   auto end_ptr = data + row_ptr[ridx + 1];
-  EntryOneAPI* previous_middle = nullptr;
+  Entry* previous_middle = nullptr;
   while (end_ptr != begin_ptr) {
     auto middle = begin_ptr + (end_ptr - begin_ptr) / 2;
     if (middle == previous_middle) {
@@ -230,7 +224,7 @@ float GetFvalue(int ridx, int fidx, EntryOneAPI* data, size_t* row_ptr, bool& is
   return 0.0;
 }
 
-float GetLeafWeight(int ridx, const DeviceNodeOneAPI* tree, EntryOneAPI* data, size_t* row_ptr) {
+float GetLeafWeight(int ridx, const DeviceNodeOneAPI* tree, Entry* data, size_t* row_ptr) {
   DeviceNodeOneAPI n = tree[0];
   int node_id = 0;
   bool is_missing;
@@ -252,11 +246,58 @@ float GetLeafWeight(int ridx, const DeviceNodeOneAPI* tree, EntryOneAPI* data, s
   return n.GetWeight();
 }
 
-class PredictorOneAPI : public Predictor {
+void DevicePredictInternal(cl::sycl::queue qu,
+                           DeviceMatrixOneAPI* dmat,
+                           HostDeviceVector<float>* out_preds,
+                           const gbm::GBTreeModel& model,
+                           size_t tree_begin,
+                           size_t tree_end) {
+  if (tree_end - tree_begin == 0) {
+    return;
+  }
+  DeviceModelOneAPI device_model;
+  device_model.Init(qu, model, tree_begin, tree_end);
+
+  auto& out_preds_vec = out_preds->HostVector();
+
+  DeviceNodeOneAPI* nodes = device_model.nodes_.Data();
+  cl::sycl::buffer<float, 1> out_preds_buf(out_preds_vec.data(), out_preds_vec.size());
+  size_t* tree_segments = device_model.tree_segments_.Data();
+  int* tree_group = device_model.tree_group_.Data();
+  size_t* row_ptr = dmat->row_ptr.Data();
+  Entry* data = dmat->data.Data();
+  int num_features = dmat->p_mat->Info().num_col_;
+  int num_rows = dmat->row_ptr.Size() - 1;
+  int num_group = model.learner_model_param->num_output_group;
+
+  qu.submit([&](cl::sycl::handler& cgh) {
+    auto out_predictions = out_preds_buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<class PredictInternal>(cl::sycl::range<1>(num_rows), [=](cl::sycl::id<1> pid) {
+      int global_idx = pid[0];
+      if (global_idx >= num_rows) return;
+      if (num_group == 1) {
+        float sum = 0.0;
+        for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
+          const DeviceNodeOneAPI* tree = nodes + tree_segments[tree_idx - tree_begin];
+          sum += GetLeafWeight(global_idx, tree, data, row_ptr);
+        }
+        out_predictions[global_idx] += sum;
+      } else {
+        for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
+          const DeviceNodeOneAPI* tree = nodes + tree_segments[tree_idx - tree_begin];
+          int out_prediction_idx = global_idx * num_group + tree_group[tree_idx];
+          out_predictions[out_prediction_idx] += GetLeafWeight(global_idx, tree, data, row_ptr);
+        }
+      }
+    });
+  }).wait();
+}
+
+class GPUPredictorOneAPI : public Predictor {
  protected:
   void InitOutPredictions(const MetaInfo& info,
                           HostDeviceVector<bst_float>* out_preds,
-                          const gbm::GBTreeModel& model) const {
+                          const gbm::GBTreeModel& model) const override {
     CHECK_NE(model.learner_model_param->num_output_group, 0);
     size_t n = model.learner_model_param->num_output_group * info.num_row_;
     const auto& base_margin = info.base_margin_.HostVector();
@@ -286,163 +327,94 @@ class PredictorOneAPI : public Predictor {
     }
   }
 
-  void DevicePredictInternal(DeviceMatrixOneAPI* dmat, HostDeviceVector<float>* out_preds,
-                             const gbm::GBTreeModel& model, size_t tree_begin,
-                             size_t tree_end) {
-    if (tree_end - tree_begin == 0) {
-      return;
-    }
-    model_.Init(model, tree_begin, tree_end, qu_);
-
-    auto& out_preds_vec = out_preds->HostVector();
-
-    DeviceNodeOneAPI* nodes = model_.nodes;
-    cl::sycl::buffer<float, 1> out_preds_buf(out_preds_vec.data(), out_preds_vec.size());
-    size_t* tree_segments = model_.tree_segments;
-    int* tree_group = model_.tree_group;
-    size_t* row_ptr = dmat->row_ptr;
-    EntryOneAPI* data = dmat->data;
-    int num_features = dmat->p_mat->Info().num_col_;
-    int num_rows = dmat->row_ptr_size - 1;
-    int num_group = model.learner_model_param->num_output_group;
-
-    qu_.submit([&](cl::sycl::handler& cgh) {
-      auto out_predictions = out_preds_buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-      cgh.parallel_for<class PredictInternal>(cl::sycl::range<1>(num_rows), [=](cl::sycl::id<1> pid) {
-        int global_idx = pid[0];
-        if (global_idx >= num_rows) return;
-        if (num_group == 1) {
-          float sum = 0.0;
-          for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
-            const DeviceNodeOneAPI* tree = nodes + tree_segments[tree_idx - tree_begin];
-            sum += GetLeafWeight(global_idx, tree, data, row_ptr);
-          }
-          out_predictions[global_idx] += sum;
-        } else {
-          for (int tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
-            const DeviceNodeOneAPI* tree = nodes + tree_segments[tree_idx - tree_begin];
-            int out_prediction_idx = global_idx * num_group + tree_group[tree_idx];
-            out_predictions[out_prediction_idx] += GetLeafWeight(global_idx, tree, data, row_ptr);
-          }
-        }
-      });
-    }).wait();
-  }
-
  public:
-  explicit PredictorOneAPI(GenericParameter const* generic_param) :
+  explicit GPUPredictorOneAPI(GenericParameter const* generic_param) :
       Predictor::Predictor{generic_param}, cpu_predictor(Predictor::Create("cpu_predictor", generic_param)) {
-    cl::sycl::default_selector selector;
-    qu_ = cl::sycl::queue(selector);
+    std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices();
+    if (generic_param->device_id != GenericParameter::kDefaultId) {
+      qu_ = cl::sycl::queue(devices[generic_param->device_id]);
+    } else {	
+      cl::sycl::default_selector selector;
+      qu_ = cl::sycl::queue(selector);
+    }
   }
 
-  // ntree_limit is a very problematic parameter, as it's ambiguous in the context of
-  // multi-output and forest.  Same problem exists for tree_begin
-  void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts,
-                    const gbm::GBTreeModel& model, int tree_begin,
-                    uint32_t const ntree_limit = 0) override {
+  void PredictBatch(DMatrix *dmat, PredictionCacheEntry *predts,
+                    const gbm::GBTreeModel &model, uint32_t tree_begin,
+                    uint32_t tree_end = 0) const override {
+    // Existing caching approach is not valid due to the const modifier of the PredictBatch method
+    /* 
     if (this->device_matrix_cache_.find(dmat) ==
         this->device_matrix_cache_.end()) {
       this->device_matrix_cache_.emplace(
           dmat, std::unique_ptr<DeviceMatrixOneAPI>(
-                    new DeviceMatrixOneAPI(dmat, qu_)));
+                    new DeviceMatrixOneAPI(qu_, dmat)));
     }
     DeviceMatrixOneAPI* device_matrix = device_matrix_cache_.find(dmat)->second.get();
+    */
 
-    // tree_begin is not used, right now we just enforce it to be 0.
-    CHECK_EQ(tree_begin, 0);
+    DeviceMatrixOneAPI device_matrix(qu_, dmat); // TODO: remove temporary workaround after cache fix
+
     auto* out_preds = &predts->predictions;
-    CHECK_GE(predts->version, tree_begin);
-    if (out_preds->Size() == 0 && dmat->Info().num_row_ != 0) {
-      CHECK_EQ(predts->version, 0);
-    }
-    if (predts->version == 0) {
-      // out_preds->Size() can be non-zero as it's initialized here before any tree is
-      // built at the 0^th iterator.
-      this->InitOutPredictions(dmat->Info(), out_preds, model);
+    if (tree_end == 0) {
+      tree_end = model.trees.size();
     }
 
-    uint32_t const output_groups = model.learner_model_param->num_output_group;
-    CHECK_NE(output_groups, 0);
-    // Right now we just assume ntree_limit provided by users means number of tree layers
-    // in the context of multi-output model
-    uint32_t real_ntree_limit = ntree_limit * output_groups;
-    if (real_ntree_limit == 0 || real_ntree_limit > model.trees.size()) {
-      real_ntree_limit = static_cast<uint32_t>(model.trees.size());
+    if (tree_begin < tree_end) {
+      DevicePredictInternal(qu_, &device_matrix, out_preds, model, tree_begin, tree_end);
     }
-
-    uint32_t const end_version = (tree_begin + real_ntree_limit) / output_groups;
-    // When users have provided ntree_limit, end_version can be lesser, cache is violated
-    if (predts->version > end_version) {
-      CHECK_NE(ntree_limit, 0);
-      this->InitOutPredictions(dmat->Info(), out_preds, model);
-      predts->version = 0;
-    }
-    uint32_t const beg_version = predts->version;
-    CHECK_LE(beg_version, end_version);
-
-    if (beg_version < end_version) {
-      DevicePredictInternal(device_matrix, out_preds, model,
-                            beg_version * output_groups,
-                            end_version * output_groups);
-    }
-
-    // delta means {size of forest} * {number of newly accumulated layers}
-    uint32_t delta = end_version - beg_version;
-    CHECK_LE(delta, model.trees.size());
-    predts->Update(delta);
-
-    CHECK(out_preds->Size() == output_groups * dmat->Info().num_row_ ||
-          out_preds->Size() == dmat->Info().num_row_);
   }
 
-  void InplacePredict(dmlc::any const &x, const gbm::GBTreeModel &model,
-                      float missing, PredictionCacheEntry *out_preds,
-                      uint32_t tree_begin, unsigned tree_end) const override {
-    cpu_predictor->InplacePredict(x, model, missing, out_preds, tree_begin, tree_end);
+  bool InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
+                      const gbm::GBTreeModel &model, float missing,
+                      PredictionCacheEntry *out_preds, uint32_t tree_begin,
+                      unsigned tree_end) const override {
+  	return cpu_predictor->InplacePredict(x, p_m, model, missing, out_preds, tree_begin, tree_end);
   }
 
   void PredictInstance(const SparsePage::Inst& inst,
                        std::vector<bst_float>* out_preds,
-                       const gbm::GBTreeModel& model, unsigned ntree_limit) override {
-    cpu_predictor->PredictInstance(inst, out_preds, model, ntree_limit);
+                       const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
+  	cpu_predictor->PredictInstance(inst, out_preds, model, ntree_limit);
   }
 
-  void PredictLeaf(DMatrix* p_fmat, std::vector<bst_float>* out_preds,
-                   const gbm::GBTreeModel& model, unsigned ntree_limit) override {
+  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_preds,
+                   const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
     cpu_predictor->PredictLeaf(p_fmat, out_preds, model, ntree_limit);
   }
 
-  void PredictContribution(DMatrix* p_fmat, std::vector<bst_float>* out_contribs,
+  void PredictContribution(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
                            const gbm::GBTreeModel& model, uint32_t ntree_limit,
                            std::vector<bst_float>* tree_weights,
                            bool approximate, int condition,
-                           unsigned condition_feature) override {
+                           unsigned condition_feature) const override {
     cpu_predictor->PredictContribution(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate, condition, condition_feature);
   }
 
-  void PredictInteractionContributions(DMatrix* p_fmat, std::vector<bst_float>* out_contribs,
+  void PredictInteractionContributions(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_contribs,
                                        const gbm::GBTreeModel& model, unsigned ntree_limit,
                                        std::vector<bst_float>* tree_weights,
-                                       bool approximate) override {
+                                       bool approximate) const override {
     cpu_predictor->PredictInteractionContributions(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate);
   }
 
  private:
   cl::sycl::queue qu_;
-  DeviceModelOneAPI model_;
 
-  std::mutex lock_;
   std::unique_ptr<Predictor> cpu_predictor;
-
-  std::unordered_map<DMatrix*, std::unique_ptr<DeviceMatrixOneAPI>>
-      device_matrix_cache_;
+  std::unordered_map<DMatrix*, std::unique_ptr<DeviceMatrixOneAPI>> device_matrix_cache_;
 };
 
 XGBOOST_REGISTER_PREDICTOR(PredictorOneAPI, "oneapi_predictor")
 .describe("Make predictions using DPC++.")
 .set_body([](GenericParameter const* generic_param) {
             return new PredictorOneAPI(generic_param);
+          });
+
+XGBOOST_REGISTER_PREDICTOR(GPUPredictorOneAPI, "oneapi_predictor_gpu")
+.describe("Make predictions using DPC++.")
+.set_body([](GenericParameter const* generic_param) {
+            return new GPUPredictorOneAPI(generic_param);
           });
 }  // namespace predictor
 }  // namespace xgboost

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -1029,6 +1029,8 @@ SparsePage::Push(const data::DenseAdapterBatch& batch, float missing, int nthrea
 template uint64_t
 SparsePage::Push(const data::CSRAdapterBatch& batch, float missing, int nthread);
 template uint64_t
+SparsePage::Push(const data::CSRArrayAdapterBatch& batch, float missing, int nthread);
+template uint64_t
 SparsePage::Push(const data::CSCAdapterBatch& batch, float missing, int nthread);
 template uint64_t
 SparsePage::Push(const data::DataTableAdapterBatch& batch, float missing, int nthread);


### PR DESCRIPTION
Continuation of the original PRs: [5659](https://github.com/dmlc/xgboost/pull/5659), [6212](https://github.com/dmlc/xgboost/pull/6212).

Part of the oneAPI plugin, containing the following:
- Fixed broken compatibility of predictor interfaces;
- Added multiclass objective function;