### PR TITLE
oneAPI DPC++-based plugin: Updater implementation, python tests, cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,10 @@ if (USE_CUDA)
   xgboost_set_cuda_flags(xgboost)
 endif (USE_CUDA)
 
+if (PLUGIN_UPDATER_ONEAPI)
+  target_compile_definitions(xgboost PRIVATE -DXGBOOST_USE_ONEAPI=1)
+endif (PLUGIN_UPDATER_ONEAPI)
+
 #-- Hide all C++ symbols
 if (HIDE_CXX_SYMBOLS)
   foreach(target objxgboost xgboost dmlc)

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -30,6 +30,7 @@ if (PLUGIN_UPDATER_ONEAPI)
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/hist_util_oneapi.cc
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/regression_obj_oneapi.cc
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/multiclass_obj_oneapi.cc
+    ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/updater_quantile_hist_oneapi.cc
     ${xgboost_SOURCE_DIR}/plugin/updater_oneapi/predictor_oneapi.cc)
   target_include_directories(oneapi_plugin
     PRIVATE

--- a/plugin/updater_oneapi/data_oneapi.h
+++ b/plugin/updater_oneapi/data_oneapi.h
@@ -47,7 +47,7 @@ public:
 
   USMVector(cl::sycl::queue qu, size_t size, T v) : qu_(qu), size_(size) {
     data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
-    qu_.fill(data_.get(), v, size_);
+    qu_.fill(data_.get(), v, size_).wait();
   }
 
   USMVector(cl::sycl::queue qu, const std::vector<T> &vec) : qu_(qu) {
@@ -97,7 +97,7 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu_.memcpy(data_old.get(), data_.get(), size_old);
+        qu_.memcpy(data_.get(), data_old.get(), sizeof(T) * size_old).wait();
       }
     }
   }
@@ -112,10 +112,10 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu_.memcpy(data_old.get(), data_.get(), size_old);
+        qu_.memcpy(data_.get(), data_old.get(), sizeof(T) * size_old).wait();
       }
       if (size_new > size_old) {
-        qu_.fill(data_.get() + size_old, v, size_new - size_old);
+        qu_.fill(data_.get() + size_old, v, size_new - size_old).wait();
       }
     }
   }

--- a/plugin/updater_oneapi/param_oneapi.h
+++ b/plugin/updater_oneapi/param_oneapi.h
@@ -1,0 +1,141 @@
+/*!
+ * Copyright 2014-2021 by Contributors
+ */
+#ifndef XGBOOST_TREE_PARAM_ONEAPI_H_
+#define XGBOOST_TREE_PARAM_ONEAPI_H_
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "xgboost/parameter.h"
+#include "xgboost/data.h"
+
+namespace xgboost {
+namespace tree {
+
+/*! \brief Wrapper for necessary training parameters for regression tree to access on device */
+struct TrainParamOneAPI {
+  float min_child_weight;
+  float reg_lambda;
+  float reg_alpha;
+  float max_delta_step;
+
+  TrainParamOneAPI() {}
+
+  TrainParamOneAPI(const TrainParam& param) {
+    reg_lambda = param.reg_lambda;
+    reg_alpha = param.reg_alpha;
+    min_child_weight = param.min_child_weight;
+    max_delta_step = param.max_delta_step;
+  }
+};
+
+/*!
+ * \brief OneAPI implementation of SplitEntryContainer for device compilation.
+ *        Original structure cannot be used due to std::isinf usage, which is not supported
+ */
+template<typename GradientT>
+struct SplitEntryContainerOneAPI {
+  /*! \brief loss change after split this node */
+  bst_float loss_chg {0.0f};
+  /*! \brief split index */
+  bst_feature_t sindex{0};
+  bst_float split_value{0.0f};
+
+  GradientT left_sum;
+  GradientT right_sum;
+
+  SplitEntryContainerOneAPI() = default;
+
+  friend std::ostream& operator<<(std::ostream& os, SplitEntryContainerOneAPI const& s) {
+    os << "loss_chg: " << s.loss_chg << ", "
+       << "split index: " << s.SplitIndex() << ", "
+       << "split value: " << s.split_value << ", "
+       << "left_sum: " << s.left_sum << ", "
+       << "right_sum: " << s.right_sum;
+    return os;
+  }
+  /*!\return feature index to split on */
+  bst_feature_t SplitIndex() const { return sindex & ((1U << 31) - 1U); }
+  /*!\return whether missing value goes to left branch */
+  bool DefaultLeft() const { return (sindex >> 31) != 0; }
+  /*!
+   * \brief decides whether we can replace current entry with the given statistics
+   *
+   *   This function gives better priority to lower index when loss_chg == new_loss_chg.
+   *   Not the best way, but helps to give consistent result during multi-thread
+   *   execution.
+   *
+   * \param new_loss_chg the loss reduction get through the split
+   * \param split_index the feature index where the split is on
+   */
+  bool NeedReplace(bst_float new_loss_chg, unsigned split_index) const {
+    if (cl::sycl::isinf(new_loss_chg)) {  // in some cases new_loss_chg can be NaN or Inf,
+                                         // for example when lambda = 0 & min_child_weight = 0
+                                         // skip value in this case
+      return false;
+    } else if (this->SplitIndex() <= split_index) {
+      return new_loss_chg > this->loss_chg;
+    } else {
+      return !(this->loss_chg > new_loss_chg);
+    }
+  }
+  /*!
+   * \brief update the split entry, replace it if e is better
+   * \param e candidate split solution
+   * \return whether the proposed split is better and can replace current split
+   */
+  inline bool Update(const SplitEntryContainerOneAPI &e) {
+    if (this->NeedReplace(e.loss_chg, e.SplitIndex())) {
+      this->loss_chg = e.loss_chg;
+      this->sindex = e.sindex;
+      this->split_value = e.split_value;
+      this->left_sum = e.left_sum;
+      this->right_sum = e.right_sum;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  /*!
+   * \brief update the split entry, replace it if e is better
+   * \param new_loss_chg loss reduction of new candidate
+   * \param split_index feature index to split on
+   * \param new_split_value the split point
+   * \param default_left whether the missing value goes to left
+   * \return whether the proposed split is better and can replace current split
+   */
+  bool Update(bst_float new_loss_chg, unsigned split_index,
+              bst_float new_split_value, bool default_left,
+              const GradientT &left_sum,
+              const GradientT &right_sum) {
+    if (this->NeedReplace(new_loss_chg, split_index)) {
+      this->loss_chg = new_loss_chg;
+      if (default_left) {
+        split_index |= (1U << 31);
+      }
+      this->sindex = split_index;
+      this->split_value = new_split_value;
+      this->left_sum = left_sum;
+      this->right_sum = right_sum;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /*! \brief same as update, used by AllReduce*/
+  inline static void Reduce(SplitEntryContainerOneAPI &dst,         // NOLINT(*)
+                            const SplitEntryContainerOneAPI &src) { // NOLINT(*)
+    dst.Update(src);
+  }
+};
+
+using SplitEntryOneAPI = SplitEntryContainerOneAPI<GradStats>;
+
+}
+}
+#endif  // XGBOOST_TREE_PARAM_H_

--- a/plugin/updater_oneapi/predictor_oneapi.cc
+++ b/plugin/updater_oneapi/predictor_oneapi.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright by Contributors 2017-2020
+ * Copyright by Contributors 2017-2021
  */
 #include <cstddef>
 #include <limits>

--- a/plugin/updater_oneapi/regression_loss_oneapi.h
+++ b/plugin/updater_oneapi/regression_loss_oneapi.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017-2020 XGBoost contributors
+ * Copyright 2017-2021 XGBoost contributors
  */
 #ifndef XGBOOST_OBJECTIVE_REGRESSION_LOSS_ONEAPI_H_
 #define XGBOOST_OBJECTIVE_REGRESSION_LOSS_ONEAPI_H_

--- a/plugin/updater_oneapi/split_evaluator_oneapi.h
+++ b/plugin/updater_oneapi/split_evaluator_oneapi.h
@@ -1,0 +1,191 @@
+/*!
+ * Copyright 2018-2021 by Contributors
+ */
+
+#ifndef XGBOOST_TREE_SPLIT_EVALUATOR_ONEAPI_H_
+#define XGBOOST_TREE_SPLIT_EVALUATOR_ONEAPI_H_
+
+#include <dmlc/registry.h>
+#include <xgboost/base.h>
+#include <utility>
+#include <vector>
+#include <limits>
+
+#include "param_oneapi.h"
+
+#include "xgboost/tree_model.h"
+#include "xgboost/host_device_vector.h"
+#include "xgboost/generic_parameters.h"
+#include "../../src/common/transform.h"
+#include "../../src/common/math.h"
+#include "../../src/tree/param.h"
+
+#include "CL/sycl.hpp"
+
+namespace xgboost {
+namespace tree {
+
+/*! \brief OneAPI implementation of TreeEvaluator, with USM memory for temporary buffer to access on device.
+ *         It also contains own implementation of SplitEvaluator for device compilation, because some of the
+           functions from the original SplitEvaluator are currently not supported
+ */
+
+class TreeEvaluatorOneAPI {
+  // hist and exact use parent id to calculate constraints.
+  static constexpr bst_node_t kRootParentId =
+      (-1 & static_cast<bst_node_t>((1U << 31) - 1));
+
+  USMVector<float> lower_bounds_;
+  USMVector<float> upper_bounds_;
+  USMVector<int32_t> monotone_;
+  TrainParamOneAPI param_;
+  cl::sycl::queue qu_;
+  bool has_constraint_;
+
+ public:
+  TreeEvaluatorOneAPI(cl::sycl::queue qu, TrainParam const& p, bst_feature_t n_features) {
+    qu_ = qu;
+    if (p.monotone_constraints.empty()) {
+      monotone_.Resize(qu_, n_features, 0);
+      has_constraint_ = false;
+    } else {
+      monotone_ = USMVector<int32_t>(qu_, p.monotone_constraints);
+      monotone_.Resize(qu_, n_features, 0);
+      lower_bounds_.Resize(qu_, p.MaxNodes(), -std::numeric_limits<float>::max());
+      upper_bounds_.Resize(qu_, p.MaxNodes(), std::numeric_limits<float>::max());
+      has_constraint_ = true;
+    }
+    param_ = TrainParamOneAPI(p);
+  }
+
+  struct SplitEvaluator {
+    int* constraints;
+    float* lower;
+    float* upper;
+    bool has_constraint;
+    TrainParamOneAPI param;
+
+    float CalcSplitGain(bst_node_t nidx,
+                        bst_feature_t fidx,
+                        tree::GradStats left,
+                        tree::GradStats right) const {
+      int constraint = constraints[fidx];
+      const float negative_infinity = -std::numeric_limits<float>::infinity();
+      float wleft = this->CalcWeight(nidx, left);
+      float wright = this->CalcWeight(nidx, right);
+
+      float gain = this->CalcGainGivenWeight(nidx, left, wleft) +
+                    this->CalcGainGivenWeight(nidx, right, wright);
+      if (constraint == 0) {
+        return gain;
+      } else if (constraint > 0) {
+        return wleft <= wright ? gain : negative_infinity;
+      } else {
+        return wleft >= wright ? gain : negative_infinity;
+      }
+    }
+
+    inline float ThresholdL1OneAPI(float w, float alpha) const {
+      if (w > + alpha) {
+        return w - alpha;
+      }
+      if (w < - alpha) {
+        return w + alpha;
+      }
+      return 0.0;
+    }
+
+    inline float CalcWeightOneAPI(float sum_grad, float sum_hess) const {
+      if (sum_hess < param.min_child_weight || sum_hess <= 0.0) {
+        return 0.0;
+      }
+      float dw = -this->ThresholdL1OneAPI(sum_grad, param.reg_alpha) / (sum_hess + param.reg_lambda);
+      if (param.max_delta_step != 0.0f && std::abs(dw) > param.max_delta_step) {
+        dw = cl::sycl::copysign((float)param.max_delta_step, dw);
+      }         
+      return dw;
+    }
+    
+    inline float CalcWeight(bst_node_t nodeid, tree::GradStats stats) const {
+      float w = this->CalcWeightOneAPI(stats.GetGrad(), stats.GetHess());
+      if (!has_constraint) {
+        return w;
+      }
+
+      if (nodeid == kRootParentId) {
+        return w;
+      } else if (w < lower[nodeid]) {
+        return lower[nodeid];
+      } else if (w > upper[nodeid]) {
+        return upper[nodeid];
+      } else {
+        return w;
+      }
+    }
+
+    inline float Sqr(float a) const { return a * a; }
+
+    inline float CalcGainGivenWeight(float sum_grad, float sum_hess, float w) const {
+      return -(2.0f * sum_grad * w + (sum_hess + param.reg_lambda) * this->Sqr(w));
+    }
+    
+    inline float CalcGainGivenWeight(bst_node_t nid, tree::GradStats stats, float w) const {
+      if (stats.GetHess() <= 0) {
+        return .0f;
+      }
+      // Avoiding tree::CalcGainGivenWeight can significantly reduce avg floating point error.
+      if (param.max_delta_step == 0.0f && has_constraint == false) {
+        return this->Sqr(this->ThresholdL1OneAPI(stats.sum_grad, param.reg_alpha)) /
+               (stats.sum_hess + param.reg_lambda);
+      }
+      return this->CalcGainGivenWeight(stats.sum_grad, stats.sum_hess, w);
+    }
+
+    float CalcGain(bst_node_t nid, tree::GradStats stats) const {
+      return this->CalcGainGivenWeight(nid, stats, this->CalcWeight(nid, stats));
+    }
+  };
+
+ public:
+  /* Get a view to the evaluator that can be passed down to device. */
+  auto GetEvaluator() {
+    return SplitEvaluator{monotone_.Data(),
+                          lower_bounds_.Data(),
+                          upper_bounds_.Data(),
+                          has_constraint_,
+                          param_};
+  }
+
+  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid,
+                bst_feature_t f, float left_weight, float right_weight) {
+    if (!has_constraint_) {
+      return;
+    }
+    float* lower = lower_bounds_.Data();
+    float* upper = upper_bounds_.Data();
+    int* monotone = monotone_.Data();
+    qu_.submit([&](cl::sycl::handler& cgh) {
+      cgh.parallel_for<>(cl::sycl::range<1>(1), [=](cl::sycl::item<1> pid) {
+        lower[leftid] = lower[nodeid];
+        upper[leftid] = upper[nodeid];
+
+        lower[rightid] = lower[nodeid];
+        upper[rightid] = upper[nodeid];
+        int32_t c = monotone[f];
+        bst_float mid = (left_weight + right_weight) / 2;
+
+        if (c < 0) {
+          lower[leftid] = mid;
+          upper[rightid] = mid;
+        } else if (c > 0) {
+          upper[leftid] = mid;
+          lower[rightid] = mid;
+        }
+      });
+    }).wait();
+  }
+};
+}  // namespace tree
+}  // namespace xgboost
+
+#endif  // XGBOOST_TREE_SPLIT_EVALUATOR_ONEAPI_H_

--- a/plugin/updater_oneapi/updater_quantile_hist_oneapi.cc
+++ b/plugin/updater_oneapi/updater_quantile_hist_oneapi.cc
@@ -1,0 +1,1332 @@
+/*!
+ * Copyright 2017-2021 by Contributors
+ * \file updater_quantile_hist_oneapi.cc
+ */
+#include <dmlc/timer.h>
+#include <rabit/rabit.h>
+
+#include "xgboost/logging.h"
+#include "xgboost/tree_updater.h"
+
+#include "./updater_quantile_hist_oneapi.h"
+#include "data_oneapi.h"
+
+namespace xgboost {
+namespace tree {
+
+DMLC_REGISTRY_FILE_TAG(updater_quantile_hist_oneapi);
+
+void QuantileHistMakerOneAPI::Configure(const Args& args) {
+  GenericParameter param;
+  param.UpdateAllowUnknown(args);
+
+  bool is_cpu = false;
+  std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices();
+  for (size_t i = 0; i < devices.size(); i++)
+  {
+    LOG(INFO) << "device_id = " << i << ", name = " << devices[i].get_info<cl::sycl::info::device::name>();
+  }
+  if (param.device_id != GenericParameter::kDefaultId) {
+    int n_devices = (int)devices.size();
+    CHECK_LT(param.device_id, n_devices);
+    is_cpu = devices[param.device_id].is_cpu() | devices[param.device_id].is_host();
+  }
+  LOG(INFO) << "device_id = " << param.device_id << ", is_cpu = " << int(is_cpu);
+
+  if (is_cpu)
+  {
+    updater_backend_.reset(TreeUpdater::Create("grow_quantile_histmaker", tparam_));
+    updater_backend_->Configure(args);
+  }
+  else
+  {
+    updater_backend_.reset(TreeUpdater::Create("grow_quantile_histmaker_oneapi_gpu", tparam_));
+    updater_backend_->Configure(args);
+  }
+}
+
+void QuantileHistMakerOneAPI::Update(HostDeviceVector<GradientPair> *gpair,
+                                     DMatrix *dmat,
+                                     const std::vector<RegTree *> &trees) {
+  updater_backend_->Update(gpair, dmat, trees);
+}
+
+bool QuantileHistMakerOneAPI::UpdatePredictionCache(
+    const DMatrix* data,
+    HostDeviceVector<bst_float>* out_preds) {
+  return updater_backend_->UpdatePredictionCache(data, out_preds);
+}
+
+void GPUQuantileHistMakerOneAPI::Configure(const Args& args) {
+  GenericParameter param;
+  param.UpdateAllowUnknown(args);
+
+  std::vector<cl::sycl::device> devices = cl::sycl::device::get_devices();
+
+  if (param.device_id != GenericParameter::kDefaultId) {
+    qu_ = cl::sycl::queue(devices[param.device_id]);
+  } else {
+    cl::sycl::default_selector selector;
+    qu_ = cl::sycl::queue(selector);
+  }
+
+  // initialize pruner
+  if (!pruner_) {
+    pruner_.reset(TreeUpdater::Create("prune", tparam_));
+  }
+  pruner_->Configure(args);
+  param_.UpdateAllowUnknown(args);
+  hist_maker_param_.UpdateAllowUnknown(args);
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::SetBuilder(std::unique_ptr<Builder<GradientSumT>>* builder,
+                                            DMatrix *dmat) {
+  builder->reset(new Builder<GradientSumT>(
+                qu_,
+                param_,
+                std::move(pruner_),
+                int_constraint_, dmat));
+  if (rabit::IsDistributed()) {
+    (*builder)->SetHistSynchronizer(new DistributedHistSynchronizerOneAPI<GradientSumT>());
+    (*builder)->SetHistRowsAdder(new DistributedHistRowsAdderOneAPI<GradientSumT>());
+  } else {
+    (*builder)->SetHistSynchronizer(new BatchHistSynchronizerOneAPI<GradientSumT>());
+    (*builder)->SetHistRowsAdder(new BatchHistRowsAdderOneAPI<GradientSumT>());
+  }
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::CallBuilderUpdate(const std::unique_ptr<Builder<GradientSumT>>& builder,
+                                                   HostDeviceVector<GradientPair> *gpair,
+                                                   DMatrix *dmat,
+                                                   const std::vector<RegTree *> &trees) {
+  for (auto tree : trees) {
+    builder->Update(gmat_, column_matrix_, gpair, dmat, tree);
+  }
+}
+void GPUQuantileHistMakerOneAPI::Update(HostDeviceVector<GradientPair> *gpair,
+                                        DMatrix *dmat,
+                                        const std::vector<RegTree *> &trees) {
+  if (dmat != p_last_dmat_ || is_gmat_initialized_ == false) {
+    updater_monitor_.Start("GmatInitialization");
+    DeviceMatrixOneAPI dmat_device(qu_, dmat);
+    gmat_.Init(qu_, dmat_device, static_cast<uint32_t>(param_.max_bin));
+    column_matrix_.Init(qu_, gmat_, dmat_device, param_.sparse_threshold);
+    updater_monitor_.Stop("GmatInitialization");
+    is_gmat_initialized_ = true;
+  }
+  // rescale learning rate according to size of trees
+  float lr = param_.learning_rate;
+  param_.learning_rate = lr / trees.size();
+  int_constraint_.Configure(param_, dmat->Info().num_col_);
+  // build tree
+  if (hist_maker_param_.single_precision_histogram) {
+    if (!float_builder_) {
+      SetBuilder(&float_builder_, dmat);
+    }
+    CallBuilderUpdate(float_builder_, gpair, dmat, trees);
+  } else {
+    if (!double_builder_) {
+      SetBuilder(&double_builder_, dmat);
+    }
+    CallBuilderUpdate(double_builder_, gpair, dmat, trees);
+  }
+
+  param_.learning_rate = lr;
+
+  p_last_dmat_ = dmat;
+}
+
+bool GPUQuantileHistMakerOneAPI::UpdatePredictionCache(const DMatrix* data,
+                                                       HostDeviceVector<bst_float>* out_preds) {
+  if (param_.subsample < 1.0f) {
+    return false;
+  } else {
+    if (hist_maker_param_.single_precision_histogram && float_builder_) {
+        return float_builder_->UpdatePredictionCache(data, out_preds);
+    } else if (double_builder_) {
+        return double_builder_->UpdatePredictionCache(data, out_preds);
+    } else {
+       return false;
+    }
+  }
+}
+
+template <typename GradientSumT>
+void BatchHistSynchronizerOneAPI<GradientSumT>::SyncHistograms(BuilderT *builder,
+                                                               std::vector<int>& sync_ids,
+                                                               RegTree *p_tree) {
+  builder->builder_monitor_.Start("SyncHistograms");
+  const size_t nbins = builder->hist_builder_.GetNumBins();
+
+  for (int i = 0; i < builder->nodes_for_explicit_hist_build_.size(); i++) {
+    const auto entry = builder->nodes_for_explicit_hist_build_[i];
+    auto this_hist = builder->hist_[entry.nid];
+
+    if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
+      const size_t parent_id = (*p_tree)[entry.nid].Parent();
+      auto parent_hist = builder->hist_[parent_id];
+      auto sibling_hist = builder->hist_[entry.sibling_nid];
+      common::SubtractionHist(builder->qu_, sibling_hist, parent_hist, this_hist, nbins);
+    }
+  }
+  builder->builder_monitor_.Stop("SyncHistograms");
+}
+
+template <typename GradientSumT>
+void DistributedHistSynchronizerOneAPI<GradientSumT>::SyncHistograms(BuilderT* builder,
+                                                                     std::vector<int>& sync_ids,
+                                                                     RegTree *p_tree) {
+  builder->builder_monitor_.Start("SyncHistograms");
+  const size_t nbins = builder->hist_builder_.GetNumBins();
+  for (int node = 0; node < builder->nodes_for_explicit_hist_build_.size(); node++) {
+    const auto entry = builder->nodes_for_explicit_hist_build_[node];
+    auto this_hist = builder->hist_[entry.nid];
+    // Store posible parent node
+    auto this_local = builder->hist_local_worker_[entry.nid];
+    common::CopyHist(builder->qu_, this_local, this_hist, nbins);
+
+    if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
+      const size_t parent_id = (*p_tree)[entry.nid].Parent();
+      auto parent_hist = builder->hist_local_worker_[parent_id];
+      auto sibling_hist = builder->hist_[entry.sibling_nid];
+      common::SubtractionHist(builder->qu_, sibling_hist, parent_hist, this_hist, nbins);
+      // Store posible parent node
+      auto sibling_local = builder->hist_local_worker_[entry.sibling_nid];
+      common::CopyHist(builder->qu_, sibling_local, sibling_hist, nbins);
+    }
+  }
+  builder->ReduceHists(sync_ids, nbins);
+
+  ParallelSubtractionHist(builder, builder->nodes_for_explicit_hist_build_, p_tree);
+  ParallelSubtractionHist(builder, builder->nodes_for_subtraction_trick_, p_tree);
+
+  builder->builder_monitor_.Stop("SyncHistograms");
+}
+
+template <typename GradientSumT>
+void DistributedHistSynchronizerOneAPI<GradientSumT>::ParallelSubtractionHist(
+    BuilderT* builder,
+    const std::vector<ExpandEntryT>& nodes,
+    const RegTree * p_tree) {
+  const size_t nbins = builder->hist_builder_.GetNumBins();
+  for (int node = 0; node < nodes.size(); node++) {
+    const auto entry = nodes[node];
+    if (!((*p_tree)[entry.nid].IsLeftChild())) {
+      auto this_hist = builder->hist_[entry.nid];
+
+      if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
+        auto parent_hist = builder->hist_[(*p_tree)[entry.nid].Parent()];
+        auto sibling_hist = builder->hist_[entry.sibling_nid];
+        common::SubtractionHist(builder->qu_, this_hist, parent_hist, sibling_hist, nbins);
+      }
+    }
+  }
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::ReduceHists(std::vector<int>& sync_ids, size_t nbins) {
+  std::vector<GradientPairT> reduce_buffer(sync_ids.size() * nbins);
+  for (size_t i = 0; i < sync_ids.size(); i++) {
+    auto this_hist = hist_[sync_ids[i]];
+    const GradientPairT* psrc = reinterpret_cast<const GradientPairT*>(this_hist.DataConst());
+    std::copy(psrc, psrc + nbins, reduce_buffer.begin() + i * nbins);
+  }
+  histred_.Allreduce(reduce_buffer.data(), nbins * sync_ids.size());
+  for (size_t i = 0; i < sync_ids.size(); i++) {
+    auto this_hist = hist_[sync_ids[i]];
+    GradientPairT* psrc = reinterpret_cast<GradientPairT*>(this_hist.Data());
+    std::copy(reduce_buffer.begin() + i * nbins, reduce_buffer.begin() + (i + 1) * nbins, psrc);
+  }
+}
+
+template <typename GradientSumT>
+void BatchHistRowsAdderOneAPI<GradientSumT>::AddHistRows(BuilderT *builder,
+                                                         std::vector<int>& sync_ids,
+                                                         RegTree *p_tree) {
+  builder->builder_monitor_.Start("AddHistRows");
+
+  for (auto const& entry : builder->nodes_for_explicit_hist_build_) {
+    int nid = entry.nid;
+    builder->hist_.AddHistRow(nid);
+  }
+
+  for (auto const& node : builder->nodes_for_subtraction_trick_) {
+    builder->hist_.AddHistRow(node.nid);
+  }
+
+  builder->builder_monitor_.Stop("AddHistRows");
+}
+
+template <typename GradientSumT>
+void DistributedHistRowsAdderOneAPI<GradientSumT>::AddHistRows(BuilderT *builder,
+                                                               std::vector<int>& sync_ids,
+                                                               RegTree *p_tree) {
+  builder->builder_monitor_.Start("AddHistRows");
+  const size_t explicit_size = builder->nodes_for_explicit_hist_build_.size();
+  const size_t subtaction_size = builder->nodes_for_subtraction_trick_.size();
+  std::vector<int> merged_node_ids(explicit_size + subtaction_size);
+  for (size_t i = 0; i < explicit_size; ++i) {
+    merged_node_ids[i] = builder->nodes_for_explicit_hist_build_[i].nid;
+  }
+  for (size_t i = 0; i < subtaction_size; ++i) {
+    merged_node_ids[explicit_size + i] =
+    builder->nodes_for_subtraction_trick_[i].nid;
+  }
+  std::sort(merged_node_ids.begin(), merged_node_ids.end());
+  sync_ids.clear();
+  for (auto const& nid : merged_node_ids) {
+    if ((*p_tree)[nid].IsLeftChild()) {
+      builder->hist_.AddHistRow(nid);
+      builder->hist_local_worker_.AddHistRow(nid);
+      sync_ids.push_back(nid);
+    }
+  }
+  for (auto const& nid : merged_node_ids) {
+    if (!((*p_tree)[nid].IsLeftChild())) {
+      builder->hist_.AddHistRow(nid);
+      builder->hist_local_worker_.AddHistRow(nid);
+    }
+  }
+  builder->builder_monitor_.Stop("AddHistRows");
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::SetHistSynchronizer(
+    HistSynchronizerOneAPI<GradientSumT> *sync) {
+  hist_synchronizer_.reset(sync);
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::SetHistRowsAdder(
+    HistRowsAdderOneAPI<GradientSumT> *adder) {
+  hist_rows_adder_.reset(adder);
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::BuildHistogramsLossGuide(
+    ExpandEntry entry,
+    const GHistIndexMatrixOneAPI &gmat,
+    RegTree *p_tree,
+    const std::vector<GradientPair> &gpair_h,
+    const USMVector<GradientPair> &gpair_device) {
+  nodes_for_explicit_hist_build_.clear();
+  nodes_for_subtraction_trick_.clear();
+  nodes_for_explicit_hist_build_.push_back(entry);
+
+  if (entry.sibling_nid > -1) {
+    nodes_for_subtraction_trick_.emplace_back(entry.sibling_nid, entry.nid,
+        p_tree->GetDepth(entry.sibling_nid), 0.0f, 0);
+  }
+
+  std::vector<int> sync_ids;
+
+  hist_rows_adder_->AddHistRows(this, sync_ids, p_tree);
+  BuildLocalHistograms(gmat, p_tree, gpair_h, gpair_device);
+  hist_synchronizer_->SyncHistograms(this, sync_ids, p_tree);
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::BuildLocalHistograms(
+    const GHistIndexMatrixOneAPI &gmat,
+    RegTree *p_tree,
+    const std::vector<GradientPair> &gpair_h,
+    const USMVector<GradientPair> &gpair_device) {
+  builder_monitor_.Start("BuildLocalHistogramsOneAPI");
+  const size_t n_nodes = nodes_for_explicit_hist_build_.size();
+  hist_buffer_.Reset(64);
+  for (size_t i = 0; i < n_nodes; i++) {
+    const int32_t nid = nodes_for_explicit_hist_build_[i].nid;
+
+    if (row_set_collection_[nid].Size() > 0) {
+      BuildHist(gpair_h, gpair_device, row_set_collection_[nid], gmat, hist_[nid], hist_buffer_.GetDeviceBuffer());
+    } else {
+      common::InitHist(qu_, hist_[nid], hist_[nid].Size());
+    }
+  }
+  builder_monitor_.Stop("BuildLocalHistogramsOneAPI");
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::BuildNodeStats(
+    const GHistIndexMatrixOneAPI &gmat,
+    DMatrix *p_fmat,
+    RegTree *p_tree,
+    const std::vector<GradientPair> &gpair_h,
+    const USMVector<GradientPair> &gpair_device) {
+  builder_monitor_.Start("BuildNodeStats");
+  for (auto const& entry : qexpand_depth_wise_) {
+    int nid = entry.nid;
+    this->InitNewNode(nid, gmat, gpair_h, gpair_device, *p_fmat, *p_tree);
+    // add constraints
+    if (!(*p_tree)[nid].IsLeftChild() && !(*p_tree)[nid].IsRoot()) {
+      // it's a right child
+      auto parent_id = (*p_tree)[nid].Parent();
+      auto left_sibling_id = (*p_tree)[parent_id].LeftChild();
+      auto parent_split_feature_id = snode_[parent_id].best.SplitIndex();
+      tree_evaluator_.AddSplit(
+          parent_id, left_sibling_id, nid, parent_split_feature_id,
+          snode_[left_sibling_id].weight, snode_[nid].weight);
+      interaction_constraints_.Split(parent_id, parent_split_feature_id,
+                                     left_sibling_id, nid);
+    }
+  }
+  builder_monitor_.Stop("BuildNodeStats");
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::AddSplitsToTree(
+    const GHistIndexMatrixOneAPI &gmat,
+    RegTree *p_tree,
+    int *num_leaves,
+    int depth,
+    unsigned *timestamp,
+    std::vector<ExpandEntry>* nodes_for_apply_split,
+    std::vector<ExpandEntry>* temp_qexpand_depth) {
+  auto evaluator = tree_evaluator_.GetEvaluator();
+  for (auto const& entry : qexpand_depth_wise_) {
+    int nid = entry.nid;
+
+    if (snode_[nid].best.loss_chg < kRtEps ||
+        (param_.max_depth > 0 && depth == param_.max_depth) ||
+        (param_.max_leaves > 0 && (*num_leaves) == param_.max_leaves)) {
+      (*p_tree)[nid].SetLeaf(snode_[nid].weight * param_.learning_rate);
+    } else {
+      nodes_for_apply_split->push_back(entry);
+
+      NodeEntry& e = snode_[nid];
+      bst_float left_leaf_weight =
+          evaluator.CalcWeight(nid, GradStats{e.best.left_sum}) * param_.learning_rate;
+      bst_float right_leaf_weight =
+          evaluator.CalcWeight(nid, GradStats{e.best.right_sum}) * param_.learning_rate;
+      p_tree->ExpandNode(nid, e.best.SplitIndex(), e.best.split_value,
+                         e.best.DefaultLeft(), e.weight, left_leaf_weight,
+                         right_leaf_weight, e.best.loss_chg, e.stats.GetHess(),
+                         e.best.left_sum.GetHess(), e.best.right_sum.GetHess());
+
+      int left_id = (*p_tree)[nid].LeftChild();
+      int right_id = (*p_tree)[nid].RightChild();
+      temp_qexpand_depth->push_back(ExpandEntry(left_id, right_id,
+                                                p_tree->GetDepth(left_id), 0.0, (*timestamp)++));
+      temp_qexpand_depth->push_back(ExpandEntry(right_id, left_id,
+                                                p_tree->GetDepth(right_id), 0.0, (*timestamp)++));
+      // - 1 parent + 2 new children
+      (*num_leaves)++;
+    }
+  }
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::EvaluateAndApplySplits(
+    const GHistIndexMatrixOneAPI &gmat,
+    const ColumnMatrixOneAPI &column_matrix,
+    RegTree *p_tree,
+    int *num_leaves,
+    int depth,
+    unsigned *timestamp,
+    std::vector<ExpandEntry> *temp_qexpand_depth) {
+  EvaluateSplits(qexpand_depth_wise_, gmat, hist_, *p_tree);
+
+  std::vector<ExpandEntry> nodes_for_apply_split;
+  AddSplitsToTree(gmat, p_tree, num_leaves, depth, timestamp,
+                  &nodes_for_apply_split, temp_qexpand_depth);
+  ApplySplit(nodes_for_apply_split, gmat, column_matrix, hist_, p_tree);
+}
+
+// Split nodes to 2 sets depending on amount of rows in each node
+// Histograms for small nodes will be built explicitly
+// Histograms for big nodes will be built by 'Subtraction Trick'
+// Exception: in distributed setting, we always build the histogram for the left child node
+//    and use 'Subtraction Trick' to built the histogram for the right child node.
+//    This ensures that the workers operate on the same set of tree nodes.
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::SplitSiblings(
+    const std::vector<ExpandEntry> &nodes,
+    std::vector<ExpandEntry> *small_siblings,
+    std::vector<ExpandEntry> *big_siblings,
+    RegTree *p_tree) {
+  builder_monitor_.Start("SplitSiblings");
+  for (auto const& entry : nodes) {
+    int nid = entry.nid;
+    RegTree::Node &node = (*p_tree)[nid];
+    if (node.IsRoot()) {
+      small_siblings->push_back(entry);
+    } else {
+      const int32_t left_id = (*p_tree)[node.Parent()].LeftChild();
+      const int32_t right_id = (*p_tree)[node.Parent()].RightChild();
+
+      if (nid == left_id && row_set_collection_[left_id ].Size() <
+                            row_set_collection_[right_id].Size()) {
+        small_siblings->push_back(entry);
+      } else if (nid == right_id && row_set_collection_[right_id].Size() <=
+                                    row_set_collection_[left_id ].Size()) {
+        small_siblings->push_back(entry);
+      } else {
+        big_siblings->push_back(entry);
+      }
+    }
+  }
+  builder_monitor_.Stop("SplitSiblings");
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::ExpandWithDepthWise(
+    const GHistIndexMatrixOneAPI &gmat,
+    const ColumnMatrixOneAPI &column_matrix,
+    DMatrix *p_fmat,
+    RegTree *p_tree,
+    const std::vector<GradientPair> &gpair_h,
+    const USMVector<GradientPair> &gpair_device) {
+  unsigned timestamp = 0;
+  int num_leaves = 0;
+
+  // in depth_wise growing, we feed loss_chg with 0.0 since it is not used anyway
+  qexpand_depth_wise_.emplace_back(ExpandEntry(ExpandEntry::kRootNid, ExpandEntry::kEmptyNid,
+      p_tree->GetDepth(ExpandEntry::kRootNid), 0.0, timestamp++));
+  ++num_leaves;
+  for (int depth = 0; depth < param_.max_depth + 1; depth++) {
+    std::vector<int> sync_ids;
+    std::vector<ExpandEntry> temp_qexpand_depth;
+    SplitSiblings(qexpand_depth_wise_, &nodes_for_explicit_hist_build_,
+                  &nodes_for_subtraction_trick_, p_tree);
+    hist_rows_adder_->AddHistRows(this, sync_ids, p_tree);
+    BuildLocalHistograms(gmat, p_tree, gpair_h, gpair_device);
+    hist_synchronizer_->SyncHistograms(this, sync_ids, p_tree);
+    BuildNodeStats(gmat, p_fmat, p_tree, gpair_h, gpair_device);
+
+    EvaluateAndApplySplits(gmat, column_matrix, p_tree, &num_leaves, depth, &timestamp,
+                   &temp_qexpand_depth);
+
+    // clean up
+    qexpand_depth_wise_.clear();
+    nodes_for_subtraction_trick_.clear();
+    nodes_for_explicit_hist_build_.clear();
+    if (temp_qexpand_depth.empty()) {
+      break;
+    } else {
+      qexpand_depth_wise_ = temp_qexpand_depth;
+      temp_qexpand_depth.clear();
+    }
+  }
+}
+
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::ExpandWithLossGuide(
+    const GHistIndexMatrixOneAPI& gmat,
+    const ColumnMatrixOneAPI& column_matrix,
+    DMatrix* p_fmat,
+    RegTree* p_tree,
+    const std::vector<GradientPair>& gpair_h,
+    const USMVector<GradientPair> &gpair_device) {
+  builder_monitor_.Start("ExpandWithLossGuide");
+  unsigned timestamp = 0;
+  int num_leaves = 0;
+
+  ExpandEntry node(ExpandEntry::kRootNid, ExpandEntry::kEmptyNid,
+      p_tree->GetDepth(0), 0.0f, timestamp++);
+  BuildHistogramsLossGuide(node, gmat, p_tree, gpair_h, gpair_device);
+
+  this->InitNewNode(ExpandEntry::kRootNid, gmat, gpair_h, gpair_device, *p_fmat, *p_tree);
+
+  this->EvaluateSplits({node}, gmat, hist_, *p_tree);
+  node.loss_chg = snode_[ExpandEntry::kRootNid].best.loss_chg;
+
+  qexpand_loss_guided_->push(node);
+  ++num_leaves;
+
+  while (!qexpand_loss_guided_->empty()) {
+    const ExpandEntry candidate = qexpand_loss_guided_->top();
+    const int nid = candidate.nid;
+    qexpand_loss_guided_->pop();
+    if (candidate.IsValid(param_, num_leaves)) {
+      (*p_tree)[nid].SetLeaf(snode_[nid].weight * param_.learning_rate);
+    } else {
+      auto evaluator = tree_evaluator_.GetEvaluator();
+      NodeEntry& e = snode_[nid];
+      bst_float left_leaf_weight =
+          evaluator.CalcWeight(nid, GradStats{e.best.left_sum}) * param_.learning_rate;
+      bst_float right_leaf_weight =
+          evaluator.CalcWeight(nid, GradStats{e.best.right_sum}) * param_.learning_rate;
+      p_tree->ExpandNode(nid, e.best.SplitIndex(), e.best.split_value,
+                         e.best.DefaultLeft(), e.weight, left_leaf_weight,
+                         right_leaf_weight, e.best.loss_chg, e.stats.GetHess(),
+                         e.best.left_sum.GetHess(), e.best.right_sum.GetHess());
+
+      this->ApplySplit({candidate}, gmat, column_matrix, hist_, p_tree);
+
+      const int cleft = (*p_tree)[nid].LeftChild();
+      const int cright = (*p_tree)[nid].RightChild();
+
+      ExpandEntry left_node(cleft, cright, p_tree->GetDepth(cleft),
+                            0.0f, timestamp++);
+      ExpandEntry right_node(cright, cleft, p_tree->GetDepth(cright),
+                            0.0f, timestamp++);
+
+      if (row_set_collection_[cleft].Size() < row_set_collection_[cright].Size()) {
+        BuildHistogramsLossGuide(left_node, gmat, p_tree, gpair_h, gpair_device);
+      } else {
+        BuildHistogramsLossGuide(right_node, gmat, p_tree, gpair_h, gpair_device);
+      }
+
+      this->InitNewNode(cleft, gmat, gpair_h, gpair_device, *p_fmat, *p_tree);
+      this->InitNewNode(cright, gmat, gpair_h, gpair_device, *p_fmat, *p_tree);
+      bst_uint featureid = snode_[nid].best.SplitIndex();
+      tree_evaluator_.AddSplit(nid, cleft, cright, featureid,
+                               snode_[cleft].weight, snode_[cright].weight);
+      interaction_constraints_.Split(nid, featureid, cleft, cright);
+
+      this->EvaluateSplits({left_node, right_node}, gmat, hist_, *p_tree);
+      left_node.loss_chg = snode_[cleft].best.loss_chg;
+      right_node.loss_chg = snode_[cright].best.loss_chg;
+
+      qexpand_loss_guided_->push(left_node);
+      qexpand_loss_guided_->push(right_node);
+
+      ++num_leaves;  // give two and take one, as parent is no longer a leaf
+    }
+  }
+  builder_monitor_.Stop("ExpandWithLossGuide");
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::Update(
+    const GHistIndexMatrixOneAPI &gmat,
+    const ColumnMatrixOneAPI &column_matrix,
+    HostDeviceVector<GradientPair> *gpair,
+    DMatrix *p_fmat,
+    RegTree *p_tree) {
+  builder_monitor_.Start("Update");
+
+  const std::vector<GradientPair>& gpair_h = gpair->ConstHostVector();
+
+  USMVector<GradientPair> gpair_device(qu_, gpair_h);
+
+  tree_evaluator_ = TreeEvaluatorOneAPI(qu_, param_, p_fmat->Info().num_col_);
+  interaction_constraints_.Reset();
+
+  this->InitData(gmat, gpair_h, gpair_device, *p_fmat, *p_tree);
+  if (param_.grow_policy == TrainParam::kLossGuide) {
+    ExpandWithLossGuide(gmat, column_matrix, p_fmat, p_tree, gpair_h, gpair_device);
+  } else {
+    ExpandWithDepthWise(gmat, column_matrix, p_fmat, p_tree, gpair_h, gpair_device);
+  }
+
+  for (int nid = 0; nid < p_tree->param.num_nodes; ++nid) {
+    p_tree->Stat(nid).loss_chg = snode_[nid].best.loss_chg;
+    p_tree->Stat(nid).base_weight = snode_[nid].weight;
+    p_tree->Stat(nid).sum_hess = static_cast<float>(snode_[nid].stats.GetHess());
+  }
+  pruner_->Update(gpair, p_fmat, std::vector<RegTree*>{p_tree});
+
+  builder_monitor_.Stop("Update");
+}
+
+template<typename GradientSumT>
+bool GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::UpdatePredictionCache(
+    const DMatrix* data,
+    HostDeviceVector<bst_float>* p_out_preds) {
+  // p_last_fmat_ is a valid pointer as long as UpdatePredictionCache() is called in
+  // conjunction with Update().
+  if (!p_last_fmat_ || !p_last_tree_ || data != p_last_fmat_) {
+    return false;
+  }
+  builder_monitor_.Start("UpdatePredictionCache");
+
+  std::vector<bst_float>& out_preds = p_out_preds->HostVector();
+  cl::sycl::buffer<float, 1> out_preds_buf(out_preds.data(), out_preds.size());
+
+  CHECK_GT(out_preds.size(), 0U);
+
+  size_t n_nodes = row_set_collection_.Size();
+  for (size_t node = 0; node < n_nodes; node++) {
+    const RowSetCollectionOneAPI::Elem& rowset = row_set_collection_[node];
+    if (rowset.begin != nullptr && rowset.end != nullptr && rowset.Size() != 0) {
+      int nid = rowset.node_id;
+      bst_float leaf_value;
+      // if a node is marked as deleted by the pruner, traverse upward to locate
+      // a non-deleted leaf.
+      if ((*p_last_tree_)[nid].IsDeleted()) {
+        while ((*p_last_tree_)[nid].IsDeleted()) {
+          nid = (*p_last_tree_)[nid].Parent();
+        }
+        CHECK((*p_last_tree_)[nid].IsLeaf());
+      }
+      leaf_value = (*p_last_tree_)[nid].LeafValue();
+
+      const size_t* rid = rowset.begin;
+      const size_t num_rows = rowset.Size();
+
+      qu_.submit([&](cl::sycl::handler& cgh) {
+        auto out_predictions = out_preds_buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for<class PredictInternal>(cl::sycl::range<1>(num_rows), [=](cl::sycl::item<1> pid) {
+          out_predictions[rid[pid.get_id(0)]] += leaf_value;
+        });
+      }).wait();
+    }
+  }
+
+  builder_monitor_.Stop("UpdatePredictionCache");
+  return true;
+}
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::InitSampling(const std::vector<GradientPair>& gpair,
+                                                const USMVector<GradientPair>& gpair_device,
+                                                const DMatrix& fmat,
+                                                USMVector<size_t>& row_indices) {
+  const auto& info = fmat.Info();
+  auto& rnd = common::GlobalRandom();
+#if XGBOOST_CUSTOMIZE_GLOBAL_PRNG
+  std::bernoulli_distribution coin_flip(param_.subsample);
+  size_t j = 0;
+  for (size_t i = 0; i < info.num_row_; ++i) {
+    if (gpair[i].GetHess() >= 0.0f && coin_flip(rnd)) {
+      row_indices[j++] = i;
+    }
+  }
+  /* resize row_indices to reduce memory */
+  row_indices.Resize(qu_, j);
+#else
+  const size_t nthread = this->nthread_;
+  std::vector<size_t> row_offsets(nthread, 0);
+  /* usage of mt19937_64 give 2x speed up for subsampling */
+  std::vector<std::mt19937> rnds(nthread);
+  /* create engine for each thread */
+  for (std::mt19937& r : rnds) {
+    r = rnd;
+  }
+  const size_t discard_size = info.num_row_ / nthread;
+  #pragma omp parallel num_threads(nthread)
+  {
+    const size_t tid = omp_get_thread_num();
+    const size_t ibegin = tid * discard_size;
+    const size_t iend = (tid == (nthread - 1)) ?
+                        info.num_row_ : ibegin + discard_size;
+    std::bernoulli_distribution coin_flip(param_.subsample);
+
+    rnds[tid].discard(2*discard_size * tid);
+    for (size_t i = ibegin; i < iend; ++i) {
+      if (gpair[i].GetHess() >= 0.0f && coin_flip(rnds[tid])) {
+        row_indices[ibegin + row_offsets[tid]++] = i;
+      }
+    }
+  }
+  /* discard global engine */
+  rnd = rnds[nthread - 1];
+  size_t prefix_sum = row_offsets[0];
+  for (size_t i = 1; i < nthread; ++i) {
+    const size_t ibegin = i * discard_size;
+
+    for (size_t k = 0; k < row_offsets[i]; ++k) {
+      row_indices[prefix_sum + k] = row_indices[ibegin + k];
+    }
+    prefix_sum += row_offsets[i];
+  }
+  /* resize row_indices to reduce memory */
+  row_indices.Resize(qu_, prefix_sum);
+#endif  // XGBOOST_CUSTOMIZE_GLOBAL_PRNG
+}
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::InitData(const GHistIndexMatrixOneAPI& gmat,
+                                          const std::vector<GradientPair>& gpair,
+                                          const USMVector<GradientPair>& gpair_device,
+                                          const DMatrix& fmat,
+                                          const RegTree& tree) {
+  CHECK((param_.max_depth > 0 || param_.max_leaves > 0))
+      << "max_depth or max_leaves cannot be both 0 (unlimited); "
+      << "at least one should be a positive quantity.";
+  if (param_.grow_policy == TrainParam::kDepthWise) {
+    CHECK(param_.max_depth > 0) << "max_depth cannot be 0 (unlimited) "
+                                << "when grow_policy is depthwise.";
+  }
+  builder_monitor_.Start("InitData");
+  const auto& info = fmat.Info();
+
+  {
+    // initialize the row set
+    row_set_collection_.Clear();
+    // initialize histogram collection
+    uint32_t nbins = gmat.cut.Ptrs().back();
+    hist_.Init(qu_, nbins);
+    hist_local_worker_.Init(qu_, nbins);
+    hist_buffer_.Init(qu_, nbins);
+
+    // initialize histogram builder
+#pragma omp parallel
+    {
+      this->nthread_ = omp_get_num_threads();
+    }
+    hist_builder_ = GHistBuilderOneAPI<GradientSumT>(qu_, nbins);
+
+    USMVector<size_t>& row_indices = row_set_collection_.Data();
+    row_indices.Resize(qu_, info.num_row_);
+    size_t* p_row_indices = row_indices.Data();
+    // mark subsample and build list of member rows
+
+    if (param_.subsample < 1.0f) {
+      CHECK_EQ(param_.sampling_method, TrainParam::kUniform)
+        << "Only uniform sampling is supported, "
+        << "gradient-based sampling is only support by GPU Hist.";
+      InitSampling(gpair, gpair_device, fmat, row_indices);
+    } else {
+      MemStackAllocatorOneAPI<bool, 128> buff(this->nthread_);
+      bool* p_buff = buff.Get();
+      std::fill(p_buff, p_buff + this->nthread_, false);
+
+      const size_t block_size = info.num_row_ / this->nthread_ + !!(info.num_row_ % this->nthread_);
+
+      #pragma omp parallel num_threads(this->nthread_)
+      {
+        const size_t tid = omp_get_thread_num();
+        const size_t ibegin = tid * block_size;
+        const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
+            static_cast<size_t>(info.num_row_));
+
+        for (size_t i = ibegin; i < iend; ++i) {
+          if (gpair[i].GetHess() < 0.0f) {
+            p_buff[tid] = true;
+            break;
+          }
+        }
+      }
+
+      bool has_neg_hess = false;
+      for (int32_t tid = 0; tid < this->nthread_; ++tid) {
+        if (p_buff[tid]) {
+          has_neg_hess = true;
+        }
+      }
+
+      if (has_neg_hess) {
+        size_t j = 0;
+        for (size_t i = 0; i < info.num_row_; ++i) {
+          if (gpair[i].GetHess() >= 0.0f) {
+            p_row_indices[j++] = i;
+          }
+        }
+        row_indices.Resize(qu_, j);
+      } else {
+        #pragma omp parallel num_threads(this->nthread_)
+        {
+          const size_t tid = omp_get_thread_num();
+          const size_t ibegin = tid * block_size;
+          const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
+              static_cast<size_t>(info.num_row_));
+          for (size_t i = ibegin; i < iend; ++i) {
+           p_row_indices[i] = i;
+          }
+        }
+      }
+    }
+  }
+
+  row_set_collection_.Init();
+
+  {
+    /* determine layout of data */
+    const size_t nrow = info.num_row_;
+    const size_t ncol = info.num_col_;
+    const size_t nnz = info.num_nonzero_;
+    // number of discrete bins for feature 0
+    const uint32_t nbins_f0 = gmat.cut.Ptrs()[1] - gmat.cut.Ptrs()[0];
+    if (nrow * ncol == nnz) {
+      // dense data with zero-based indexing
+      data_layout_ = kDenseDataZeroBased;
+    } else if (nbins_f0 == 0 && nrow * (ncol - 1) == nnz) {
+      // dense data with one-based indexing
+      data_layout_ = kDenseDataOneBased;
+    } else {
+      // sparse data
+      data_layout_ = kSparseData;
+    }
+  }
+  // store a pointer to the tree
+  p_last_tree_ = &tree;
+  if (data_layout_ == kDenseDataOneBased) {
+    column_sampler_.Init(info.num_col_, info.feature_weigths.ConstHostVector(),
+                         param_.colsample_bynode, param_.colsample_bylevel,
+                         param_.colsample_bytree, true);
+  } else {
+    column_sampler_.Init(info.num_col_, info.feature_weigths.ConstHostVector(),
+                         param_.colsample_bynode, param_.colsample_bylevel,
+                         param_.colsample_bytree, false);
+  }
+  if (data_layout_ == kDenseDataZeroBased || data_layout_ == kDenseDataOneBased) {
+    /* specialized code for dense data:
+       choose the column that has a least positive number of discrete bins.
+       For dense data (with no missing value),
+       the sum of gradient histogram is equal to snode[nid] */
+    const std::vector<uint32_t>& row_ptr = gmat.cut.Ptrs();
+    const auto nfeature = static_cast<bst_uint>(row_ptr.size() - 1);
+    uint32_t min_nbins_per_feature = 0;
+    for (bst_uint i = 0; i < nfeature; ++i) {
+      const uint32_t nbins = row_ptr[i + 1] - row_ptr[i];
+      if (nbins > 0) {
+        if (min_nbins_per_feature == 0 || min_nbins_per_feature > nbins) {
+          min_nbins_per_feature = nbins;
+          fid_least_bins_ = i;
+        }
+      }
+    }
+    CHECK_GT(min_nbins_per_feature, 0U);
+  }
+  {
+    snode_.Clear();
+  }
+  {
+    if (param_.grow_policy == TrainParam::kLossGuide) {
+      qexpand_loss_guided_.reset(new ExpandQueue(LossGuide));
+    } else {
+      qexpand_depth_wise_.clear();
+    }
+  }
+  builder_monitor_.Stop("InitData");
+}
+
+// if sum of statistics for non-missing values in the node
+// is equal to sum of statistics for all values:
+// then - there are no missing values
+// else - there are missing values
+template <typename GradientSumT>
+bool GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::SplitContainsMissingValues(
+    const GradStats e, const NodeEntry &snode) {
+  if (e.GetGrad() == snode.stats.GetGrad() && e.GetHess() == snode.stats.GetHess()) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+// nodes_set - set of nodes to be processed in parallel
+template<typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::EvaluateSplits(
+                                               const std::vector<ExpandEntry>& nodes_set,
+                                               const GHistIndexMatrixOneAPI& gmat,
+                                               const HistCollectionOneAPI<GradientSumT>& hist,
+                                               const RegTree& tree) {
+  builder_monitor_.Start("EvaluateSplits");
+
+  const size_t n_nodes_in_set = nodes_set.size();
+  const size_t nthread = std::max(1, this->nthread_);
+
+  using FeatureSetType = std::shared_ptr<HostDeviceVector<bst_feature_t>>;
+  std::vector<FeatureSetType> features_sets(n_nodes_in_set);
+
+  // Generate feature set for each tree node
+  size_t total_features = 0;
+  for (size_t nid_in_set = 0; nid_in_set < n_nodes_in_set; ++nid_in_set) {
+    const int32_t nid = nodes_set[nid_in_set].nid;
+    features_sets[nid_in_set] = column_sampler_.GetFeatureSet(tree.GetDepth(nid));
+    for (size_t idx_in_feature_set = 0; idx_in_feature_set < features_sets[nid_in_set]->Size(); idx_in_feature_set++) {
+      const auto fid = features_sets[nid_in_set]->ConstHostVector()[idx_in_feature_set];
+      if (interaction_constraints_.Query(nid, fid)) {
+        total_features++;
+      }
+    }
+  }
+
+  split_queries_device_.Resize(qu_, total_features);
+
+  size_t pos = 0;
+
+  for (size_t nid_in_set = 0; nid_in_set < n_nodes_in_set; ++nid_in_set) {
+    const size_t nid = nodes_set[nid_in_set].nid;
+
+    for (size_t idx_in_feature_set = 0; idx_in_feature_set < features_sets[nid_in_set]->Size(); idx_in_feature_set++) {
+      const auto fid = features_sets[nid_in_set]->ConstHostVector()[idx_in_feature_set];
+      if (interaction_constraints_.Query(nid, fid)) {
+        split_queries_device_[pos].nid = nid;
+        split_queries_device_[pos].fid = fid;
+        split_queries_device_[pos].hist = hist[nid].DataConst();
+        split_queries_device_[pos].best = snode_[nid].best;
+        pos++;
+      }
+    }
+  }
+
+  auto evaluator = tree_evaluator_.GetEvaluator();
+  SplitQuery* split_queries_device = split_queries_device_.Data();
+  const uint32_t* cut_ptr = gmat.cut_device.Ptrs().DataConst();
+  const bst_float* cut_val = gmat.cut_device.Values().DataConst();
+  const bst_float* cut_minval = gmat.cut_device.MinValues().DataConst();
+  const NodeEntry* snode = snode_.DataConst();
+
+  TrainParamOneAPI param(param_);
+
+  qu_.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for<>(cl::sycl::range<1>(total_features), [=](cl::sycl::item<1> pid) {
+      TrainParamOneAPI param_device(param);
+      TreeEvaluatorOneAPI::SplitEvaluator evaluator_device = evaluator;
+      int i = pid.get_id(0);
+      int nid = split_queries_device[i].nid;
+      int fid = split_queries_device[i].fid;
+      const GradientPairT* hist_data = split_queries_device[i].hist;
+      auto grad_stats = EnumerateSplit<+1>(cut_ptr, cut_val, cut_minval, hist_data, snode[nid],
+              split_queries_device[i].best, fid, nid, evaluator_device, param_device);
+      if (SplitContainsMissingValues(grad_stats, snode[nid])) {
+        EnumerateSplit<-1>(cut_ptr, cut_val, cut_minval, hist_data, snode[nid],
+              split_queries_device[i].best, fid, nid, evaluator_device, param_device);
+      }
+    });
+  }).wait();
+
+  for (size_t i = 0; i < total_features; i++) {
+    int nid = split_queries_device[i].nid;
+    snode_[nid].best.Update(split_queries_device[i].best);
+  }
+
+  builder_monitor_.Stop("EvaluateSplits");
+}
+
+// Enumerate the split values of specific feature.
+// Returns the sum of gradients corresponding to the data points that contains a non-missing value
+// for the particular feature fid.
+template <typename GradientSumT>
+template <int d_step>
+GradStats GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::EnumerateSplit(
+    const uint32_t* cut_ptr,
+    const bst_float* cut_val,
+    const bst_float* cut_minval,
+    const GradientPairT* hist_data,
+    const NodeEntry& snode,
+    SplitEntryOneAPI& p_best,
+    bst_uint fid,
+    bst_uint nodeID,
+    TreeEvaluatorOneAPI::SplitEvaluator const &evaluator_device,
+    const TrainParamOneAPI& param) {
+  GradStats c;
+  GradStats e;
+  // best split so far
+  SplitEntryOneAPI best;
+
+  // bin boundaries
+  // imin: index (offset) of the minimum value for feature fid
+  //       need this for backward enumeration
+  const auto imin = static_cast<int32_t>(cut_ptr[fid]);
+  // ibegin, iend: smallest/largest cut points for feature fid
+  // use int to allow for value -1
+  int32_t ibegin, iend;
+  if (d_step > 0) {
+    ibegin = static_cast<int32_t>(cut_ptr[fid]);
+    iend = static_cast<int32_t>(cut_ptr[fid + 1]);
+  } else {
+    ibegin = static_cast<int32_t>(cut_ptr[fid + 1]) - 1;
+    iend = static_cast<int32_t>(cut_ptr[fid]) - 1;
+  }
+
+  for (int32_t i = ibegin; i != iend; i += d_step) {
+    e.Add(hist_data[i].GetGrad(), hist_data[i].GetHess());
+    if (e.GetHess() >= param.min_child_weight) {
+      c.SetSubstract(snode.stats, e);
+      if (c.GetHess() >= param.min_child_weight) {
+        bst_float loss_chg;
+        bst_float split_pt;
+        if (d_step > 0) {
+          loss_chg = static_cast<bst_float>(
+              evaluator_device.CalcSplitGain(nodeID, fid, e, c) - snode.root_gain);
+          split_pt = cut_val[i];
+          best.Update(loss_chg, fid, split_pt, d_step == -1, e, c);
+        } else {
+          loss_chg = static_cast<bst_float>(
+              evaluator_device.CalcSplitGain(nodeID, fid, GradStats{c}, GradStats{e}) - snode.root_gain);
+          if (i == imin) {
+            split_pt = cut_minval[fid];
+          } else {
+            split_pt = cut_val[i - 1];
+          }
+          best.Update(loss_chg, fid, split_pt, d_step == -1, c, e);
+        }
+      }
+    }
+  }
+  p_best.Update(best);
+  return e;
+}
+
+// split row indexes (rid_span) to 2 parts (both stored in rid_buf) depending
+// on comparison of indexes values (idx_span) and split point (split_cond)
+// Handle dense columns
+template <bool default_left, bool any_missing, size_t subgroup_size, typename BinIdxType>
+inline void PartitionDenseKernel(cl::sycl::queue& qu,
+                                 const size_t node_in_set,
+                                 const common::DenseColumnOneAPI<BinIdxType>& column,
+                                 common::Span<const size_t>& rid_span,
+                                 const int32_t split_cond,
+                                 common::Span<size_t>& rid_buf,
+                                 common::Span<size_t>& prefix_sums,
+                                 cl::sycl::buffer<size_t, 1>& parts_size, 
+                                 size_t local_size) {
+  const int32_t offset = column.GetBaseIdx();
+  const BinIdxType* idx = column.GetFeatureBinIdxPtr().data();
+  const size_t* rid = &rid_span[0];
+  const size_t range_size = rid_span.size();
+  size_t n_sums = range_size / local_size + !!(range_size % local_size);
+  size_t* prefix_sums_data = &prefix_sums[0];
+
+  /* flags for missing values in dense columns */
+  bool* missing_flags = column.GetMissingFlags();
+  size_t feature_offset = column.GetFeatureOffset();
+
+  size_t* p_rid_buf = rid_buf.data();
+
+  qu.submit([&](cl::sycl::handler& cgh) {
+    auto parts_size_acc = parts_size.template get_access<cl::sycl::access::mode::atomic>(cgh);
+    cgh.parallel_for<>(cl::sycl::range<1>(range_size), [=](cl::sycl::item<1> nid) {
+      const size_t id = rid[nid.get_id(0)];
+      const bool is_left = (any_missing && missing_flags && missing_flags[feature_offset + id]) ? default_left : (static_cast<int32_t>(idx[id]) + offset) <= split_cond;
+      if (is_left) {
+        p_rid_buf[cl::sycl::atomic_fetch_add<size_t>(parts_size_acc[node_in_set * 2], 1)] = id;
+      } else {
+        p_rid_buf[range_size - cl::sycl::atomic_fetch_add<size_t>(parts_size_acc[node_in_set * 2 + 1], 1) - 1] = id;
+      }
+    });
+  }).wait();
+}
+
+template <typename GradientSumT>
+template <typename BinIdxType>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::PartitionKernel(
+    const size_t node_in_set,
+    const size_t nid,
+    common::Range1d range,
+    const int32_t split_cond,
+    const ColumnMatrixOneAPI& column_matrix,
+    const RegTree& tree,
+    cl::sycl::buffer<size_t, 1>& parts_size) {
+  const size_t* rid = row_set_collection_[nid].begin;
+
+  common::Span<const size_t> rid_span(rid + range.begin(), rid + range.end());
+  common::Span<size_t> rid_buf = partition_builder_.GetData(node_in_set);
+  common::Span<size_t> prefix_sums = partition_builder_.GetPrefixSums();
+  const size_t local_size = partition_builder_.GetLocalSize(range);
+  const bst_uint fid = tree[nid].SplitIndex();
+  const bool default_left = tree[nid].DefaultLeft();
+  const auto column_ptr = column_matrix.GetColumn<BinIdxType>(fid);
+
+  if (column_ptr->GetType() == xgboost::common::kDenseColumn) {
+    const common::DenseColumnOneAPI<BinIdxType>& column =
+          static_cast<const common::DenseColumnOneAPI<BinIdxType>& >(*(column_ptr.get()));
+    if (default_left) {
+      if (column_matrix.AnyMissing()) {
+        PartitionDenseKernel<true, true, common::PartitionBuilderOneAPI::subgroupSize>(qu_, node_in_set, column, rid_span, split_cond,
+                                                                                       rid_buf, prefix_sums, parts_size, local_size);
+      } else {
+        PartitionDenseKernel<true, false, common::PartitionBuilderOneAPI::subgroupSize>(qu_, node_in_set, column, rid_span, split_cond,
+                                                                                        rid_buf, prefix_sums, parts_size, local_size);
+      }
+    } else {
+      if (column_matrix.AnyMissing()) {
+        PartitionDenseKernel<false, true, common::PartitionBuilderOneAPI::subgroupSize>(qu_, node_in_set, column, rid_span, split_cond,
+                                                                                        rid_buf, prefix_sums, parts_size, local_size);
+      } else {
+        PartitionDenseKernel<false, false, common::PartitionBuilderOneAPI::subgroupSize>(qu_, node_in_set, column, rid_span, split_cond,
+                                                                                         rid_buf, prefix_sums, parts_size, local_size);
+      }
+    }
+  } else {
+    LOG(WARNING) << "Sparse data is currently unsupported for updater_quantile_hist_oneapi";
+  }
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::FindSplitConditions(
+    const std::vector<ExpandEntry>& nodes,
+    const RegTree& tree,
+    const GHistIndexMatrixOneAPI& gmat,
+    std::vector<int32_t>* split_conditions) {
+  const size_t n_nodes = nodes.size();
+  split_conditions->resize(n_nodes);
+
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    const int32_t nid = nodes[i].nid;
+    const bst_uint fid = tree[nid].SplitIndex();
+    const bst_float split_pt = tree[nid].SplitCond();
+    const uint32_t lower_bound = gmat.cut.Ptrs()[fid];
+    const uint32_t upper_bound = gmat.cut.Ptrs()[fid + 1];
+    int32_t split_cond = -1;
+    // convert floating-point split_pt into corresponding bin_id
+    // split_cond = -1 indicates that split_pt is less than all known cut points
+    CHECK_LT(upper_bound,
+             static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
+    for (uint32_t i = lower_bound; i < upper_bound; ++i) {
+      if (split_pt == gmat.cut.Values()[i]) {
+        split_cond = static_cast<int32_t>(i);
+      }
+    }
+    (*split_conditions)[i] = split_cond;
+  }
+}
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::AddSplitsToRowSet(const std::vector<ExpandEntry>& nodes,
+                                                                          RegTree* p_tree) {
+  const size_t n_nodes = nodes.size();
+  for (size_t i = 0; i < n_nodes; ++i) {
+    const int32_t nid = nodes[i].nid;
+    const size_t n_left = partition_builder_.GetNLeftElems(i);
+    const size_t n_right = partition_builder_.GetNRightElems(i);
+
+    row_set_collection_.AddSplit(nid, (*p_tree)[nid].LeftChild(),
+        (*p_tree)[nid].RightChild(), n_left, n_right);
+  }
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::ApplySplit(const std::vector<ExpandEntry> nodes,
+                                                                   const GHistIndexMatrixOneAPI& gmat,
+                                                                   const ColumnMatrixOneAPI& column_matrix,
+                                                                   const HistCollectionOneAPI<GradientSumT>& hist,
+                                                                   RegTree* p_tree) {
+  builder_monitor_.Start("ApplySplit");
+
+  const size_t n_nodes = nodes.size();
+  std::vector<int32_t> split_conditions;
+  FindSplitConditions(nodes, *p_tree, gmat, &split_conditions);
+
+  partition_builder_.Init(qu_, n_nodes, [&](size_t node_in_set) {
+    const int32_t nid = nodes[node_in_set].nid;
+    return row_set_collection_[nid].Size();
+  });
+
+  cl::sycl::buffer<size_t, 1> parts_size(n_nodes * 2);
+  {
+    auto parts_size_acc = parts_size.template get_access<cl::sycl::access::mode::write>();
+    for (size_t node_in_set = 0; node_in_set < n_nodes; node_in_set++) {
+      parts_size_acc[node_in_set * 2] = 0;
+      parts_size_acc[node_in_set * 2 + 1] = 0;
+    }
+  }
+  for (size_t node_in_set = 0; node_in_set < n_nodes; node_in_set++) {
+    const int32_t nid = nodes[node_in_set].nid;
+    if (row_set_collection_[nid].Size() > 0) {
+      switch (column_matrix.GetTypeSize()) {
+        case common::kUint8BinsTypeSize:
+          PartitionKernel<uint8_t>(node_in_set, nid, common::Range1d(0, row_set_collection_[nid].Size()),
+                    split_conditions[node_in_set], column_matrix, *p_tree, parts_size);
+          break;
+        case common::kUint16BinsTypeSize:
+          PartitionKernel<uint16_t>(node_in_set, nid, common::Range1d(0, row_set_collection_[nid].Size()),
+                    split_conditions[node_in_set], column_matrix, *p_tree, parts_size);
+          break;
+        case common::kUint32BinsTypeSize:
+          PartitionKernel<uint32_t>(node_in_set, nid, common::Range1d(0, row_set_collection_[nid].Size()),
+                    split_conditions[node_in_set], column_matrix, *p_tree, parts_size);
+          break;
+        default:
+          CHECK(false);  // no default behavior
+      }
+    }
+  }
+
+  {
+    auto parts_size_acc = parts_size.template get_access<cl::sycl::access::mode::write>();
+    for (size_t node_in_set = 0; node_in_set < n_nodes; node_in_set++) {
+      partition_builder_.SetNLeftElems(node_in_set, parts_size_acc[node_in_set * 2]);
+      partition_builder_.SetNRightElems(node_in_set, parts_size_acc[node_in_set * 2 + 1]);
+    }
+  }
+  partition_builder_.CalculateRowOffsets();
+
+  for (size_t node_in_set = 0; node_in_set < n_nodes; node_in_set++) {
+    const int32_t nid = nodes[node_in_set].nid;
+    partition_builder_.MergeToArray(node_in_set, const_cast<size_t*>(row_set_collection_[nid].begin));
+  }
+
+  qu_.wait();
+
+  AddSplitsToRowSet(nodes, p_tree);
+
+  builder_monitor_.Stop("ApplySplit");
+}
+
+template <typename GradientSumT>
+void GPUQuantileHistMakerOneAPI::Builder<GradientSumT>::InitNewNode(int nid,
+                                                                    const GHistIndexMatrixOneAPI& gmat,
+                                                                    const std::vector<GradientPair>& gpair,
+                                                                    const USMVector<GradientPair>& gpair_device,
+                                                                    const DMatrix& fmat,
+                                                                    const RegTree& tree) {
+  builder_monitor_.Start("InitNewNode");
+  {
+    snode_.Resize(qu_, tree.param.num_nodes, NodeEntry(param_));
+  }
+
+  {
+    auto hist = hist_[nid];
+    GradientPairT grad_stat;
+    if (tree[nid].IsRoot()) {
+      if (data_layout_ == kDenseDataZeroBased || data_layout_ == kDenseDataOneBased) {
+        const std::vector<uint32_t>& row_ptr = gmat.cut.Ptrs();
+        const uint32_t ibegin = row_ptr[fid_least_bins_];
+        const uint32_t iend = row_ptr[fid_least_bins_ + 1];
+        xgboost::detail::GradientPairInternal<GradientSumT>* begin =
+          reinterpret_cast<xgboost::detail::GradientPairInternal<GradientSumT>*>(hist.Data());
+        for (uint32_t i = ibegin; i < iend; ++i) {
+          const GradientPairT et = begin[i];
+          grad_stat.Add(et.GetGrad(), et.GetHess());
+        }
+      } else {
+        const RowSetCollectionOneAPI::Elem e = row_set_collection_[nid];
+        for (const size_t* it = e.begin; it < e.end; ++it) {
+          grad_stat.Add(gpair[*it].GetGrad(), gpair[*it].GetHess());
+        }
+      }
+      histred_.Allreduce(&grad_stat, 1);
+      snode_[nid].stats = tree::GradStats(grad_stat.GetGrad(), grad_stat.GetHess());
+    } else {
+      int parent_id = tree[nid].Parent();
+      if (tree[nid].IsLeftChild()) {
+        snode_[nid].stats = snode_[parent_id].best.left_sum;
+      } else {
+        snode_[nid].stats = snode_[parent_id].best.right_sum;
+      }
+    }
+  }
+
+  // calculating the weights
+  {
+    auto evaluator = tree_evaluator_.GetEvaluator();
+    bst_uint parentid = tree[nid].Parent();
+    snode_[nid].weight = static_cast<float>(
+        evaluator.CalcWeight(parentid, GradStats{snode_[nid].stats}));
+    snode_[nid].root_gain = static_cast<float>(
+        evaluator.CalcGain(parentid, GradStats{snode_[nid].stats}));
+  }
+  builder_monitor_.Stop("InitNewNode");
+}
+
+template struct GPUQuantileHistMakerOneAPI::Builder<float>;
+template struct GPUQuantileHistMakerOneAPI::Builder<double>;
+template void GPUQuantileHistMakerOneAPI::Builder<float>::PartitionKernel<uint8_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+template void GPUQuantileHistMakerOneAPI::Builder<float>::PartitionKernel<uint16_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+template void GPUQuantileHistMakerOneAPI::Builder<float>::PartitionKernel<uint32_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+template void GPUQuantileHistMakerOneAPI::Builder<double>::PartitionKernel<uint8_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+template void GPUQuantileHistMakerOneAPI::Builder<double>::PartitionKernel<uint16_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+template void GPUQuantileHistMakerOneAPI::Builder<double>::PartitionKernel<uint32_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrixOneAPI& column_matrix, const RegTree& tree, cl::sycl::buffer<size_t, 1>& parts_size);
+
+XGBOOST_REGISTER_TREE_UPDATER(QuantileHistMakerOneAPI, "grow_quantile_histmaker_oneapi")
+.describe("Grow tree using quantized histogram with dpc++.")
+.set_body(
+    []() {
+      return new QuantileHistMakerOneAPI();
+    });
+
+XGBOOST_REGISTER_TREE_UPDATER(GPUQuantileHistMakerOneAPI, "grow_quantile_histmaker_oneapi_gpu")
+.describe("Grow tree using quantized histogram with dpc++ on GPU.")
+.set_body(
+    []() {
+      return new GPUQuantileHistMakerOneAPI();
+    });
+}  // namespace tree
+}  // namespace xgboost

--- a/plugin/updater_oneapi/updater_quantile_hist_oneapi.cc
+++ b/plugin/updater_oneapi/updater_quantile_hist_oneapi.cc
@@ -16,6 +16,8 @@ namespace tree {
 
 DMLC_REGISTRY_FILE_TAG(updater_quantile_hist_oneapi);
 
+DMLC_REGISTER_PARAMETER(OneAPIHistMakerTrainParam);
+
 void QuantileHistMakerOneAPI::Configure(const Args& args) {
   GenericParameter param;
   param.UpdateAllowUnknown(args);

--- a/plugin/updater_oneapi/updater_quantile_hist_oneapi.h
+++ b/plugin/updater_oneapi/updater_quantile_hist_oneapi.h
@@ -1,0 +1,580 @@
+/*!
+ * Copyright 2017-2021 by Contributors
+ * \file updater_quantile_hist_oneapi.h
+ */
+#ifndef XGBOOST_TREE_UPDATER_QUANTILE_HIST_ONEAPI_H_
+#define XGBOOST_TREE_UPDATER_QUANTILE_HIST_ONEAPI_H_
+
+#include <dmlc/timer.h>
+#include <rabit/rabit.h>
+#include <xgboost/tree_updater.h>
+
+#include <queue>
+
+#include "column_matrix_oneapi.h"
+#include "hist_util_oneapi.h"
+#include "row_set_oneapi.h"
+#include "split_evaluator_oneapi.h"
+
+#include "xgboost/data.h"
+#include "xgboost/json.h"
+#include "../../src/tree/constraints.h"
+#include "../../src/common/random.h"
+
+namespace xgboost {
+
+/*!
+ * \brief A C-style array with in-stack allocation.
+          As long as the array is smaller than MaxStackSize, it will be allocated inside the stack. Otherwise, it will be heap-allocated.
+          Temporary copy of implementation to remove dependency on updater_quantile_hist.h
+ */
+template<typename T, size_t MaxStackSize>
+class MemStackAllocatorOneAPI {
+ public:
+  explicit MemStackAllocatorOneAPI(size_t required_size): required_size_(required_size) {
+  }
+
+  T* Get() {
+    if (!ptr_) {
+      if (MaxStackSize >= required_size_) {
+        ptr_ = stack_mem_;
+      } else {
+        ptr_ =  reinterpret_cast<T*>(malloc(required_size_ * sizeof(T)));
+        do_free_ = true;
+      }
+    }
+
+    return ptr_;
+  }
+
+  ~MemStackAllocatorOneAPI() {
+    if (do_free_) free(ptr_);
+  }
+
+
+ private:
+  T* ptr_ = nullptr;
+  bool do_free_ = false;
+  size_t required_size_;
+  T stack_mem_[MaxStackSize];
+};
+
+namespace tree {
+
+using xgboost::common::HistCollectionOneAPI;
+using xgboost::common::GHistBuilderOneAPI;
+using xgboost::common::GHistIndexMatrixOneAPI;
+using xgboost::common::ColumnMatrixOneAPI;
+using xgboost::common::GHistRowOneAPI;
+using xgboost::common::RowSetCollectionOneAPI;
+
+template <typename GradientSumT>
+class HistSynchronizerOneAPI;
+
+template <typename GradientSumT>
+class BatchHistSynchronizerOneAPI;
+
+template <typename GradientSumT>
+class DistributedHistSynchronizerOneAPI;
+
+template <typename GradientSumT>
+class HistRowsAdderOneAPI;
+
+template <typename GradientSumT>
+class BatchHistRowsAdderOneAPI;
+
+template <typename GradientSumT>
+class DistributedHistRowsAdderOneAPI;
+
+// training parameters specific to this algorithm
+struct OneAPIHistMakerTrainParam
+    : public XGBoostParameter<OneAPIHistMakerTrainParam> {
+  bool single_precision_histogram = false;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(OneAPIHistMakerTrainParam) {
+    DMLC_DECLARE_FIELD(single_precision_histogram).set_default(false).describe(
+        "Use single precision to build histograms.");
+  }
+};
+
+/*! \brief construct a tree using quantized feature values with DPC++ interface */
+class QuantileHistMakerOneAPI: public TreeUpdater {
+ public:
+  QuantileHistMakerOneAPI() = default;
+  void Configure(const Args& args) override;
+
+  void Update(HostDeviceVector<GradientPair>* gpair,
+              DMatrix* dmat,
+              const std::vector<RegTree*>& trees) override;
+
+  bool UpdatePredictionCache(const DMatrix* data,
+                             HostDeviceVector<bst_float>* out_preds) override;
+
+  void LoadConfig(Json const& in) override {
+  	if (updater_backend_) {
+  	  updater_backend_->LoadConfig(in);
+  	} else {
+      auto const& config = get<Object const>(in);
+      FromJson(config.at("train_param"), &this->param_);
+    }
+  }
+
+  void SaveConfig(Json* p_out) const override {
+  	if (updater_backend_) {
+  	  updater_backend_->SaveConfig(p_out);
+  	} else {
+      auto& out = *p_out;
+      out["train_param"] = ToJson(param_);
+    }
+  }
+
+  char const* Name() const override {
+    if (updater_backend_) {
+    	return updater_backend_->Name();
+    } else {
+        return "grow_quantile_histmaker_oneapi";
+    }
+  }
+
+ protected:
+  // training parameter
+  TrainParam param_;
+
+  std::unique_ptr<TreeUpdater> updater_backend_;
+};
+
+/*! \brief construct a tree using quantized feature values with DPC++ backend on GPU*/
+class GPUQuantileHistMakerOneAPI: public TreeUpdater {
+ public:
+  GPUQuantileHistMakerOneAPI() {
+    updater_monitor_.Init("GPUQuantileHistMakerOneAPI");
+  }
+  void Configure(const Args& args) override;
+
+  void Update(HostDeviceVector<GradientPair>* gpair,
+              DMatrix* dmat,
+              const std::vector<RegTree*>& trees) override;
+
+  bool UpdatePredictionCache(const DMatrix* data,
+                             HostDeviceVector<bst_float>* out_preds) override;
+
+  void LoadConfig(Json const& in) override {
+    auto const& config = get<Object const>(in);
+    FromJson(config.at("train_param"), &this->param_);
+    try {
+      FromJson(config.at("oneapi_hist_train_param"), &this->hist_maker_param_);
+    } catch (std::out_of_range& e) {
+      // XGBoost model is from 1.1.x, so 'cpu_hist_train_param' is missing.
+      // We add this compatibility check because it's just recently that we (developers) began
+      // persuade R users away from using saveRDS() for model serialization. Hopefully, one day,
+      // everyone will be using xgb.save().
+      LOG(WARNING) << "Attempted to load interal configuration for a model file that was generated "
+        << "by a previous version of XGBoost. A likely cause for this warning is that the model "
+        << "was saved with saveRDS() in R or pickle.dump() in Python. We strongly ADVISE AGAINST "
+        << "using saveRDS() or pickle.dump() so that the model remains accessible in current and "
+        << "upcoming XGBoost releases. Please use xgb.save() instead to preserve models for the "
+        << "long term. For more details and explanation, see "
+        << "https://xgboost.readthedocs.io/en/latest/tutorials/saving_model.html";
+      this->hist_maker_param_.UpdateAllowUnknown(Args{});
+    }
+  }
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["train_param"] = ToJson(param_);
+    out["oneapi_hist_train_param"] = ToJson(hist_maker_param_);
+  }
+
+  char const* Name() const override {
+    return "grow_quantile_histmaker_oneapi_gpu";
+  }
+
+ protected:
+  template <typename GradientSumT>
+  friend class HistSynchronizerOneAPI;
+  template <typename GradientSumT>
+  friend class BatchHistSynchronizerOneAPI;
+  template <typename GradientSumT>
+  friend class DistributedHistSynchronizerOneAPI;
+
+  template <typename GradientSumT>
+  friend class HistRowsAdderOneAPI;
+  template <typename GradientSumT>
+  friend class BatchHistRowsAdderOneAPI;
+  template <typename GradientSumT>
+  friend class DistributedHistRowsAdderOneAPI;
+
+  OneAPIHistMakerTrainParam hist_maker_param_;
+  // training parameter
+  TrainParam param_;
+  // quantized data matrix
+  GHistIndexMatrixOneAPI gmat_;
+  // (optional) data matrix with feature grouping
+  // column accessor
+  ColumnMatrixOneAPI column_matrix_;
+  DMatrix const* p_last_dmat_ {nullptr};
+  bool is_gmat_initialized_ {false};
+
+  // data structure
+  struct NodeEntry {
+    /*! \brief statics for node entry */
+    GradStats stats;
+    /*! \brief loss of this node, without split */
+    bst_float root_gain;
+    /*! \brief weight calculated related to current data */
+    float weight;
+    /*! \brief current best solution */
+    SplitEntryOneAPI best;
+    // constructor
+    explicit NodeEntry(const TrainParam& param)
+        : root_gain(0.0f), weight(0.0f) {}
+  };
+  // actual builder that runs the algorithm
+
+  template<typename GradientSumT>
+  struct Builder {
+   public:
+    using GHistRowT = GHistRowOneAPI<GradientSumT>;
+    using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
+    // constructor
+    explicit Builder(cl::sycl::queue qu,
+                     const TrainParam& param,
+                     std::unique_ptr<TreeUpdater> pruner,
+                     FeatureInteractionConstraintHost int_constraints_,
+                     DMatrix const* fmat)
+      : qu_(qu), param_(param),
+        tree_evaluator_(qu, param, fmat->Info().num_col_),
+        pruner_(std::move(pruner)),
+        interaction_constraints_{std::move(int_constraints_)},
+        p_last_tree_(nullptr), p_last_fmat_(fmat) {
+      builder_monitor_.Init("QuantileOneAPI::Builder");
+      kernel_monitor_.Init("QuantileOneAPI::Kernels");
+    }
+    // update one tree, growing
+    virtual void Update(const GHistIndexMatrixOneAPI& gmat,
+                        const ColumnMatrixOneAPI& column_matrix,
+                        HostDeviceVector<GradientPair>* gpair,
+                        DMatrix* p_fmat,
+                        RegTree* p_tree);
+
+    inline void BuildHist(const std::vector<GradientPair>& gpair,
+                          const USMVector<GradientPair>& gpair_device,
+                          const RowSetCollectionOneAPI::Elem row_indices,
+                          const GHistIndexMatrixOneAPI& gmat,
+                          GHistRowT& hist,
+                          GHistRowT& hist_buffer) {
+      hist_builder_.BuildHist(gpair, gpair_device, row_indices, gmat, hist, data_layout_ != kSparseData, hist_buffer);
+    }
+
+    inline void SubtractionTrick(GHistRowT& self,
+                                 GHistRowT& sibling,
+                                 GHistRowT& parent) {
+      builder_monitor_.Start("SubtractionTrick");
+      hist_builder_.SubtractionTrick(self, sibling, parent);
+      builder_monitor_.Stop("SubtractionTrick");
+    }
+
+    bool UpdatePredictionCache(const DMatrix* data,
+                               HostDeviceVector<bst_float>* p_out_preds);
+    void SetHistSynchronizer(HistSynchronizerOneAPI<GradientSumT>* sync);
+    void SetHistRowsAdder(HistRowsAdderOneAPI<GradientSumT>* adder);
+
+   protected:
+    friend class HistSynchronizerOneAPI<GradientSumT>;
+    friend class BatchHistSynchronizerOneAPI<GradientSumT>;
+    friend class DistributedHistSynchronizerOneAPI<GradientSumT>;
+    friend class HistRowsAdderOneAPI<GradientSumT>;
+    friend class BatchHistRowsAdderOneAPI<GradientSumT>;
+    friend class DistributedHistRowsAdderOneAPI<GradientSumT>;
+
+    /* tree growing policies */
+    struct ExpandEntry {
+      static const int kRootNid  = 0;
+      static const int kEmptyNid = -1;
+      int nid;
+      int sibling_nid;
+      int depth;
+      bst_float loss_chg;
+      unsigned timestamp;
+      ExpandEntry(int nid, int sibling_nid, int depth, bst_float loss_chg,
+                  unsigned tstmp)
+          : nid(nid), sibling_nid(sibling_nid), depth(depth),
+            loss_chg(loss_chg), timestamp(tstmp) {}
+
+      bool IsValid(TrainParam const &param, int32_t num_leaves) const {
+        bool ret = loss_chg <= kRtEps ||
+                   (param.max_depth > 0 && this->depth == param.max_depth) ||
+                   (param.max_leaves > 0 && num_leaves == param.max_leaves);
+        return ret;
+      }
+    };
+
+
+    struct SplitQuery {
+      int nid;
+      int fid;
+      SplitEntryOneAPI best;
+      const GradientPairT* hist;
+    };
+
+    // initialize temp data structure
+    void InitData(const GHistIndexMatrixOneAPI& gmat,
+                  const std::vector<GradientPair>& gpair,
+                  const USMVector<GradientPair>& gpair_device,
+                  const DMatrix& fmat,
+                  const RegTree& tree);
+
+    void InitSampling(const std::vector<GradientPair>& gpair,
+                      const USMVector<GradientPair>& gpair_device,
+                      const DMatrix& fmat, USMVector<size_t>& row_indices);
+
+    void EvaluateSplits(const std::vector<ExpandEntry>& nodes_set,
+                        const GHistIndexMatrixOneAPI& gmat,
+                        const HistCollectionOneAPI<GradientSumT>& hist,
+                        const RegTree& tree);
+
+    // Enumerate the split values of specific feature
+    // Returns the sum of gradients corresponding to the data points that contains a non-missing
+    // value for the particular feature fid.
+    template <int d_step>
+    static GradStats EnumerateSplit(
+        const uint32_t* cut_ptr,const bst_float* cut_val, const bst_float* cut_minval, const GradientPairT* hist_data,
+        const NodeEntry &snode, SplitEntryOneAPI& p_best, bst_uint fid,
+        bst_uint nodeID,
+        TreeEvaluatorOneAPI::SplitEvaluator const &evaluator, const TrainParamOneAPI& param);
+
+    void ApplySplit(std::vector<ExpandEntry> nodes,
+                        const GHistIndexMatrixOneAPI& gmat,
+                        const ColumnMatrixOneAPI& column_matrix,
+                        const HistCollectionOneAPI<GradientSumT>& hist,
+                        RegTree* p_tree);
+
+    template <typename BinIdxType>
+    void PartitionKernel(const size_t node_in_set, const size_t nid, common::Range1d range,
+                         const int32_t split_cond,
+                         const ColumnMatrixOneAPI& column_matrix, const RegTree& tree,
+                         cl::sycl::buffer<size_t, 1>& parts_size);
+
+    void AddSplitsToRowSet(const std::vector<ExpandEntry>& nodes, RegTree* p_tree);
+
+
+    void FindSplitConditions(const std::vector<ExpandEntry>& nodes, const RegTree& tree,
+                             const GHistIndexMatrixOneAPI& gmat, std::vector<int32_t>* split_conditions);
+
+    void InitNewNode(int nid,
+                     const GHistIndexMatrixOneAPI& gmat,
+                     const std::vector<GradientPair>& gpair,
+                     const USMVector<GradientPair>& gpair_device,
+                     const DMatrix& fmat,
+                     const RegTree& tree);
+
+    // if sum of statistics for non-missing values in the node
+    // is equal to sum of statistics for all values:
+    // then - there are no missing values
+    // else - there are missing values
+    static bool SplitContainsMissingValues(const GradStats e, const NodeEntry& snode);
+
+    void ExpandWithDepthWise(const GHistIndexMatrixOneAPI &gmat,
+                             const ColumnMatrixOneAPI &column_matrix,
+                             DMatrix *p_fmat,
+                             RegTree *p_tree,
+                             const std::vector<GradientPair> &gpair_h,
+                             const USMVector<GradientPair> &gpair_device);
+
+    void BuildLocalHistograms(const GHistIndexMatrixOneAPI &gmat,
+                              RegTree *p_tree,
+                              const std::vector<GradientPair> &gpair_h,
+                              const USMVector<GradientPair> &gpair_device);
+
+    void BuildHistogramsLossGuide(
+                        ExpandEntry entry,
+                        const GHistIndexMatrixOneAPI &gmat,
+                        RegTree *p_tree,
+                        const std::vector<GradientPair> &gpair_h,
+                        const USMVector<GradientPair> &gpair_device);
+
+    // Split nodes to 2 sets depending on amount of rows in each node
+    // Histograms for small nodes will be built explicitly
+    // Histograms for big nodes will be built by 'Subtraction Trick'
+    void SplitSiblings(const std::vector<ExpandEntry>& nodes,
+                   std::vector<ExpandEntry>* small_siblings,
+                   std::vector<ExpandEntry>* big_siblings,
+                   RegTree *p_tree);
+
+    void ParallelSubtractionHist(const common::BlockedSpace2d& space,
+                                 const std::vector<ExpandEntry>& nodes,
+                                 const RegTree * p_tree);
+
+    void BuildNodeStats(const GHistIndexMatrixOneAPI &gmat,
+                        DMatrix *p_fmat,
+                        RegTree *p_tree,
+                        const std::vector<GradientPair> &gpair_h,
+                        const USMVector<GradientPair> &gpair_device);
+
+    void EvaluateAndApplySplits(const GHistIndexMatrixOneAPI &gmat,
+                                const ColumnMatrixOneAPI &column_matrix,
+                                RegTree *p_tree,
+                                int *num_leaves,
+                                int depth,
+                                unsigned *timestamp,
+                                std::vector<ExpandEntry> *temp_qexpand_depth);
+
+    void AddSplitsToTree(
+              const GHistIndexMatrixOneAPI &gmat,
+              RegTree *p_tree,
+              int *num_leaves,
+              int depth,
+              unsigned *timestamp,
+              std::vector<ExpandEntry>* nodes_for_apply_split,
+              std::vector<ExpandEntry>* temp_qexpand_depth);
+
+    void ExpandWithLossGuide(const GHistIndexMatrixOneAPI& gmat,
+                             const ColumnMatrixOneAPI& column_matrix,
+                             DMatrix* p_fmat,
+                             RegTree* p_tree,
+                             const std::vector<GradientPair>& gpair_h,
+                             const USMVector<GradientPair>& gpair_device);
+
+    void ReduceHists(std::vector<int>& sync_ids, size_t nbins);
+
+    inline static bool LossGuide(ExpandEntry lhs, ExpandEntry rhs) {
+      if (lhs.loss_chg == rhs.loss_chg) {
+        return lhs.timestamp > rhs.timestamp;  // favor small timestamp
+      } else {
+        return lhs.loss_chg < rhs.loss_chg;  // favor large loss_chg
+      }
+    }
+    //  --data fields--
+    const TrainParam& param_;
+    // number of omp thread used during training
+    int nthread_;
+    common::ColumnSampler column_sampler_;
+    // the internal row sets
+    RowSetCollectionOneAPI row_set_collection_;
+    USMVector<SplitQuery> split_queries_device_;
+    /*! \brief TreeNode Data: statistics for each constructed node */
+    USMVector<NodeEntry> snode_;
+    /*! \brief culmulative histogram of gradients. */
+    HistCollectionOneAPI<GradientSumT> hist_;
+    /*! \brief culmulative local parent histogram of gradients. */
+    HistCollectionOneAPI<GradientSumT> hist_local_worker_;
+    TreeEvaluatorOneAPI tree_evaluator_;
+    /*! \brief feature with least # of bins. to be used for dense specialization
+               of InitNewNode() */
+    uint32_t fid_least_bins_;
+
+    GHistBuilderOneAPI<GradientSumT> hist_builder_;
+    std::unique_ptr<TreeUpdater> pruner_;
+    FeatureInteractionConstraintHost interaction_constraints_;
+
+    common::PartitionBuilderOneAPI partition_builder_;
+
+    // back pointers to tree and data matrix
+    const RegTree* p_last_tree_;
+    DMatrix const* const p_last_fmat_;
+
+    using ExpandQueue =
+       std::priority_queue<ExpandEntry, std::vector<ExpandEntry>,
+                           std::function<bool(ExpandEntry, ExpandEntry)>>;
+
+    std::unique_ptr<ExpandQueue> qexpand_loss_guided_;
+    std::vector<ExpandEntry> qexpand_depth_wise_;
+    // key is the node id which should be calculated by Subtraction Trick, value is the node which
+    // provides the evidence for substracts
+    std::vector<ExpandEntry> nodes_for_subtraction_trick_;
+    // list of nodes whose histograms would be built explicitly.
+    std::vector<ExpandEntry> nodes_for_explicit_hist_build_;
+
+    enum DataLayout { kDenseDataZeroBased, kDenseDataOneBased, kSparseData };
+    DataLayout data_layout_;
+
+    common::Monitor builder_monitor_;
+    common::Monitor kernel_monitor_;
+    common::ParallelGHistBuilderOneAPI<GradientSumT> hist_buffer_;
+    rabit::Reducer<GradientPairT, GradientPairT::Reduce> histred_;
+    std::unique_ptr<HistSynchronizerOneAPI<GradientSumT>> hist_synchronizer_;
+    std::unique_ptr<HistRowsAdderOneAPI<GradientSumT>> hist_rows_adder_;
+
+    cl::sycl::queue qu_;
+  };
+  common::Monitor updater_monitor_;
+
+  template<typename GradientSumT>
+  void SetBuilder(std::unique_ptr<Builder<GradientSumT>>*, DMatrix *dmat);
+
+  template<typename GradientSumT>
+  void CallBuilderUpdate(const std::unique_ptr<Builder<GradientSumT>>& builder,
+                         HostDeviceVector<GradientPair> *gpair,
+                         DMatrix *dmat,
+                         const std::vector<RegTree *> &trees);
+
+ protected:
+  std::unique_ptr<Builder<float>> float_builder_;
+  std::unique_ptr<Builder<double>> double_builder_;
+
+  std::unique_ptr<TreeUpdater> pruner_;
+  FeatureInteractionConstraintHost int_constraint_;
+
+  cl::sycl::queue qu_;
+};
+
+template <typename GradientSumT>
+class HistSynchronizerOneAPI {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+
+  virtual void SyncHistograms(BuilderT* builder,
+                              std::vector<int>& sync_ids,
+                              RegTree *p_tree) = 0;
+  virtual ~HistSynchronizerOneAPI() = default;
+};
+
+template <typename GradientSumT>
+class BatchHistSynchronizerOneAPI: public HistSynchronizerOneAPI<GradientSumT> {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+  void SyncHistograms(BuilderT* builder,
+                      std::vector<int>& sync_ids,
+                      RegTree *p_tree) override;
+};
+
+template <typename GradientSumT>
+class DistributedHistSynchronizerOneAPI: public HistSynchronizerOneAPI<GradientSumT> {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+  using ExpandEntryT = typename BuilderT::ExpandEntry;
+
+  void SyncHistograms(BuilderT* builder, std::vector<int>& sync_ids, RegTree *p_tree) override;
+
+  void ParallelSubtractionHist(BuilderT* builder,
+                               const std::vector<ExpandEntryT>& nodes,
+                               const RegTree * p_tree);
+};
+
+template <typename GradientSumT>
+class HistRowsAdderOneAPI {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+
+  virtual void AddHistRows(BuilderT* builder, std::vector<int>& sync_ids, RegTree *p_tree) = 0;
+  virtual ~HistRowsAdderOneAPI() = default;
+};
+
+template <typename GradientSumT>
+class BatchHistRowsAdderOneAPI: public HistRowsAdderOneAPI<GradientSumT> {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+  void AddHistRows(BuilderT*, std::vector<int>& sync_ids, RegTree *p_tree) override;
+};
+
+template <typename GradientSumT>
+class DistributedHistRowsAdderOneAPI: public HistRowsAdderOneAPI<GradientSumT> {
+ public:
+  using BuilderT = GPUQuantileHistMakerOneAPI::Builder<GradientSumT>;
+  void AddHistRows(BuilderT*, std::vector<int>& sync_ids, RegTree *p_tree) override;
+};
+
+
+}  // namespace tree
+}  // namespace xgboost
+
+#endif  // XGBOOST_TREE_UPDATER_QUANTILE_HIST_ONEAPI_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,10 @@ if (USE_CUDA)
   target_link_libraries(objxgboost PRIVATE GPUTreeShap)
 endif (USE_CUDA)
 
+if (PLUGIN_UPDATER_ONEAPI)
+  target_compile_definitions(objxgboost PRIVATE -DXGBOOST_USE_ONEAPI=1)
+endif (PLUGIN_UPDATER_ONEAPI)
+
 target_include_directories(objxgboost
   PRIVATE
   ${xgboost_SOURCE_DIR}/include

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -204,6 +204,7 @@ DMLC_REGISTER_PARAMETER(GenericParameter);
 
 int constexpr GenericParameter::kCpuId;
 int64_t constexpr GenericParameter::kDefaultSeed;
+int constexpr GenericParameter::kDefaultId;
 
 void GenericParameter::ConfigureGpuId(bool require_gpu) {
 #if defined(XGBOOST_USE_CUDA)

--- a/tests/python-oneapi/test_oneapi_prediction.py
+++ b/tests/python-oneapi/test_oneapi_prediction.py
@@ -1,0 +1,153 @@
+import sys
+import unittest
+import pytest
+
+import numpy as np
+import xgboost as xgb
+from hypothesis import given, strategies, assume, settings, note
+
+sys.path.append("tests/python")
+import testing as tm
+
+rng = np.random.RandomState(1994)
+
+shap_parameter_strategy = strategies.fixed_dictionaries({
+    'max_depth': strategies.integers(0, 11),
+    'max_leaves': strategies.integers(0, 256),
+    'num_parallel_tree': strategies.sampled_from([1, 10]),
+}).filter(lambda x: x['max_depth'] > 0 or x['max_leaves'] > 0)
+
+
+class TestOneAPIPredict(unittest.TestCase):
+    def test_predict(self):
+        iterations = 10
+        np.random.seed(1)
+        test_num_rows = [10, 1000, 5000]
+        test_num_cols = [10, 50, 500]
+        for num_rows in test_num_rows:
+            for num_cols in test_num_cols:
+                dtrain = xgb.DMatrix(np.random.randn(num_rows, num_cols),
+                                     label=[0, 1] * int(num_rows / 2))
+                dval = xgb.DMatrix(np.random.randn(num_rows, num_cols),
+                                   label=[0, 1] * int(num_rows / 2))
+                dtest = xgb.DMatrix(np.random.randn(num_rows, num_cols),
+                                    label=[0, 1] * int(num_rows / 2))
+                watchlist = [(dtrain, 'train'), (dval, 'validation')]
+                res = {}
+                param = {
+                    "objective": "binary:logistic_oneapi",
+                    "predictor": "oneapi_predictor",
+                    'eval_metric': 'logloss',
+                    'tree_method': 'hist',
+                    'updater': 'grow_quantile_histmaker_oneapi',
+                    'max_depth': 1
+                }
+                bst = xgb.train(param, dtrain, iterations, evals=watchlist,
+                                evals_result=res)
+                assert self.non_increasing(res["train"]["logloss"])
+                oneapi_pred_train = bst.predict(dtrain, output_margin=True)
+                oneapi_pred_test = bst.predict(dtest, output_margin=True)
+                oneapi_pred_val = bst.predict(dval, output_margin=True)
+
+                param["predictor"] = "cpu_predictor"
+                bst_cpu = xgb.train(param, dtrain, iterations, evals=watchlist)
+                cpu_pred_train = bst_cpu.predict(dtrain, output_margin=True)
+                cpu_pred_test = bst_cpu.predict(dtest, output_margin=True)
+                cpu_pred_val = bst_cpu.predict(dval, output_margin=True)
+
+                np.testing.assert_allclose(cpu_pred_train, oneapi_pred_train,
+                                           rtol=1e-6)
+                np.testing.assert_allclose(cpu_pred_val, oneapi_pred_val,
+                                           rtol=1e-6)
+                np.testing.assert_allclose(cpu_pred_test, oneapi_pred_test,
+                                           rtol=1e-6)
+
+    def non_increasing(self, L):
+        return all((y - x) < 0.001 for x, y in zip(L, L[1:]))
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_multi_predict(self):
+        from sklearn.datasets import make_regression
+        from sklearn.model_selection import train_test_split
+
+        n = 1000
+        X, y = make_regression(n, random_state=rng)
+        X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                            random_state=123)
+        dtrain = xgb.DMatrix(X_train, label=y_train)
+        dtest = xgb.DMatrix(X_test)
+
+        params = {}
+        params["tree_method"] = "hist"
+        params["updater"] = "grow_quantile_histmaker_oneapi"
+
+        params['predictor'] = "oneapi_predictor"
+        bst_oneapi_predict = xgb.train(params, dtrain)
+
+        params['predictor'] = "cpu_predictor"
+        bst_cpu_predict = xgb.train(params, dtrain)
+
+        predict0 = bst_oneapi_predict.predict(dtest)
+        predict1 = bst_oneapi_predict.predict(dtest)
+        cpu_predict = bst_cpu_predict.predict(dtest)
+
+        assert np.allclose(predict0, predict1)
+        assert np.allclose(predict0, cpu_predict)
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_sklearn(self):
+        m, n = 15000, 14
+        tr_size = 2500
+        X = np.random.rand(m, n)
+        y = 200 * np.matmul(X, np.arange(-3, -3 + n))
+        X_train, y_train = X[:tr_size, :], y[:tr_size]
+        X_test, y_test = X[tr_size:, :], y[tr_size:]
+
+        # First with cpu_predictor
+        params = {'tree_method': 'hist',
+                  'predictor': 'cpu_predictor',
+                  'n_jobs': -1,
+                  'seed': 123}
+        m = xgb.XGBRegressor(**params).fit(X_train, y_train)
+        cpu_train_score = m.score(X_train, y_train)
+        cpu_test_score = m.score(X_test, y_test)
+
+        # Now with oneapi_predictor
+        params['predictor'] = 'oneapi_predictor'
+
+        m = xgb.XGBRegressor(**params).fit(X_train, y_train)
+        oneapi_train_score = m.score(X_train, y_train)
+        m = xgb.XGBRegressor(**params).fit(X_train, y_train)
+        oneapi_test_score = m.score(X_test, y_test)
+
+        assert np.allclose(cpu_train_score, oneapi_train_score)
+        assert np.allclose(cpu_test_score, oneapi_test_score)
+
+    @given(strategies.integers(1, 10),
+           tm.dataset_strategy.filter(lambda x: x.name != "empty"), shap_parameter_strategy)
+    @settings(deadline=None)
+    def test_shap(self, num_rounds, dataset, param):
+        param.update({"predictor": "oneapi_predictor"})
+        param = dataset.set_params(param)
+        dmat = dataset.get_dmat()
+        bst = xgb.train(param, dmat, num_rounds)
+        test_dmat = xgb.DMatrix(dataset.X, dataset.y, dataset.w, dataset.margin)
+        shap = bst.predict(test_dmat, pred_contribs=True)
+        margin = bst.predict(test_dmat, output_margin=True)
+        assume(len(dataset.y) > 0)
+        assert np.allclose(np.sum(shap, axis=len(shap.shape) - 1), margin, 1e-3, 1e-3)
+
+    @given(strategies.integers(1, 10),
+           tm.dataset_strategy.filter(lambda x: x.name != "empty"), shap_parameter_strategy)
+    @settings(deadline=None, max_examples=20)
+    def test_shap_interactions(self, num_rounds, dataset, param):
+        param.update({"predictor": "oneapi_predictor"})
+        param = dataset.set_params(param)
+        dmat = dataset.get_dmat()
+        bst = xgb.train(param, dmat, num_rounds)
+        test_dmat = xgb.DMatrix(dataset.X, dataset.y, dataset.w, dataset.margin)
+        shap = bst.predict(test_dmat, pred_interactions=True)
+        margin = bst.predict(test_dmat, output_margin=True)
+        assume(len(dataset.y) > 0)
+        assert np.allclose(np.sum(shap, axis=(len(shap.shape) - 1, len(shap.shape) - 2)), margin,
+                           1e-3, 1e-3)

--- a/tests/python-oneapi/test_oneapi_training_continuation.py
+++ b/tests/python-oneapi/test_oneapi_training_continuation.py
@@ -1,0 +1,56 @@
+import numpy as np
+import xgboost as xgb
+import json
+
+rng = np.random.RandomState(1994)
+
+
+class TestOneAPITrainingContinuation:
+    def run_training_continuation(self, use_json):
+        kRows = 64
+        kCols = 32
+        X = np.random.randn(kRows, kCols)
+        y = np.random.randn(kRows)
+        dtrain = xgb.DMatrix(X, y)
+        params = {'updater': 'grow_quantile_histmaker_oneapi', 'max_depth': '2',
+                  'gamma': '0.1', 'alpha': '0.01',
+                  'enable_experimental_json_serialization': use_json}
+        bst_0 = xgb.train(params, dtrain, num_boost_round=64)
+        dump_0 = bst_0.get_dump(dump_format='json')
+
+        bst_1 = xgb.train(params, dtrain, num_boost_round=32)
+        bst_1 = xgb.train(params, dtrain, num_boost_round=32, xgb_model=bst_1)
+        dump_1 = bst_1.get_dump(dump_format='json')
+
+        def recursive_compare(obj_0, obj_1):
+            if isinstance(obj_0, float):
+                assert np.isclose(obj_0, obj_1, atol=1e-6)
+            elif isinstance(obj_0, str):
+                assert obj_0 == obj_1
+            elif isinstance(obj_0, int):
+                assert obj_0 == obj_1
+            elif isinstance(obj_0, dict):
+                keys_0 = list(obj_0.keys())
+                keys_1 = list(obj_1.keys())
+                values_0 = list(obj_0.values())
+                values_1 = list(obj_1.values())
+                for i in range(len(obj_0.items())):
+                    assert keys_0[i] == keys_1[i]
+                    if list(obj_0.keys())[i] != 'missing':
+                        recursive_compare(values_0[i],
+                                          values_1[i])
+            else:
+                for i in range(len(obj_0)):
+                    recursive_compare(obj_0[i], obj_1[i])
+
+        assert len(dump_0) == len(dump_1)
+        for i in range(len(dump_0)):
+            obj_0 = json.loads(dump_0[i])
+            obj_1 = json.loads(dump_1[i])
+            recursive_compare(obj_0, obj_1)
+
+    def test_oneapi_training_continuation_binary(self):
+        self.run_training_continuation(False)
+
+    def test_oneapi_training_continuation_json(self):
+        self.run_training_continuation(True)

--- a/tests/python-oneapi/test_oneapi_updaters.py
+++ b/tests/python-oneapi/test_oneapi_updaters.py
@@ -1,0 +1,51 @@
+import numpy as np
+import gc
+import pytest
+import xgboost as xgb
+from hypothesis import given, strategies, assume, settings, note
+
+import sys
+sys.path.append("tests/python")
+import testing as tm
+
+parameter_strategy = strategies.fixed_dictionaries({
+    'max_depth': strategies.integers(0, 11),
+    'max_leaves': strategies.integers(0, 256),
+    'max_bin': strategies.integers(2, 1024),
+    'grow_policy': strategies.sampled_from(['lossguide', 'depthwise']),
+    'single_precision_histogram': strategies.booleans(),
+    'min_child_weight': strategies.floats(0.5, 2.0),
+    'seed': strategies.integers(0, 10),
+    # We cannot enable subsampling as the training loss can increase
+    # 'subsample': strategies.floats(0.5, 1.0),
+    'colsample_bytree': strategies.floats(0.5, 1.0),
+    'colsample_bylevel': strategies.floats(0.5, 1.0),
+}).filter(lambda x: (x['max_depth'] > 0 or x['max_leaves'] > 0) and (
+    x['max_depth'] > 0 or x['grow_policy'] == 'lossguide'))
+
+
+def train_result(param, dmat, num_rounds):
+    result = {}
+    xgb.train(param, dmat, num_rounds, [(dmat, 'train')], verbose_eval=False,
+              evals_result=result)
+    return result
+
+
+class TestOneAPIUpdaters:
+    @given(parameter_strategy, strategies.integers(1, 5),
+           tm.dataset_strategy.filter(lambda x: x.name != "empty"))
+    @settings(deadline=None)
+    def test_oneapi_hist(self, param, num_rounds, dataset):
+        param['updater'] = 'grow_quantile_histmaker_oneapi'
+        param = dataset.set_params(param)
+        result = train_result(param, dataset.get_dmat(), num_rounds)
+        note(result)
+        assert tm.non_increasing(result['train'][dataset.metric])
+
+    @given(tm.dataset_strategy.filter(lambda x: x.name != "empty"), strategies.integers(0, 1))
+    @settings(deadline=None)
+    def test_specified_device_id_oneapi_update(self, dataset, device_id):
+        param = {'updater': 'grow_quantile_histmaker_oneapi', 'device_id': device_id}
+        param = dataset.set_params(param)
+        result = train_result(param, dataset.get_dmat(), 10)
+        assert tm.non_increasing(result['train'][dataset.metric])

--- a/tests/python-oneapi/test_oneapi_with_sklearn.py
+++ b/tests/python-oneapi/test_oneapi_with_sklearn.py
@@ -1,0 +1,35 @@
+import xgboost as xgb
+import pytest
+import sys
+import numpy as np
+
+sys.path.append("tests/python")
+import testing as tm               # noqa
+import test_with_sklearn as twskl  # noqa
+
+pytestmark = pytest.mark.skipif(**tm.no_sklearn())
+
+rng = np.random.RandomState(1994)
+
+
+def test_oneapi_binary_classification():
+    from sklearn.datasets import load_digits
+    from sklearn.model_selection import KFold
+
+    digits = load_digits(2)
+    y = digits['target']
+    X = digits['data']
+    kf = KFold(n_splits=2, shuffle=True, random_state=rng)
+    for cls in (xgb.XGBClassifier, xgb.XGBRFClassifier):
+        for train_index, test_index in kf.split(X, y):
+            xgb_model = cls(
+                random_state=42, updater='grow_quantile_histmaker_oneapi',
+                n_estimators=4, device_id=-1).fit(X[train_index], y[train_index])
+            preds = xgb_model.predict(X[test_index])
+            labels = y[test_index]
+            err = sum(1 for i in range(len(preds))
+                      if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
+            print(preds)
+            print(labels)
+            print(err)
+            assert err < 0.1


### PR DESCRIPTION
Continuation of the original PRs: [5659](https://github.com/dmlc/xgboost/pull/5659), [6212](https://github.com/dmlc/xgboost/pull/6212).

Part of the oneAPI plugin, containing the following:
- Introduction of oneAPI updater implementation;
- Adding python tests partially covering oneAPI plugin functionality;
- Small CMake tweaks to enable USE_ONEAPI defines;